### PR TITLE
NPCs spawn in awake and with a current order

### DIFF
--- a/0-SphereIICore/Scripts/Entities/EntityAliveSDX.cs
+++ b/0-SphereIICore/Scripts/Entities/EntityAliveSDX.cs
@@ -134,6 +134,27 @@ public class EntityAliveSDX : EntityNPC
             return;
         base.SetSleeper();
     }
+    
+    /// <summary>
+    /// Overrides EntityAlive.OnAddedToWorld().
+    /// When entities are spawned into sleeper volumes, which happens in SleeperVolume.Spawn(),
+    /// several of their properties are set so they are spawned in a sleeping state.
+    /// If the NPC should always be awake, those properties can be reset here.
+    /// </summary>
+    public override void OnAddedToWorld()
+    {
+        if (isAlwaysAwake)
+        {
+            // Set the current order, defaults to "Wander"
+            EntityUtilities.SetCurrentOrder(entityId, EntityUtilities.GetCurrentOrder(entityId));
+
+            // Set in EntityAlive.TriggerSleeperPose() - resetting here
+            this.IsSleeping = false;
+        }
+
+        base.OnAddedToWorld();
+    }
+    
     public void ConfigureBounaryBox(Vector3 newSize, Vector3 center)
     {
         BoxCollider component = base.gameObject.GetComponent<BoxCollider>();


### PR DESCRIPTION
Overrides EntityAlive.OnAddedToWorld to (re)set the IsSleeping property, and current order (defaults to "wander").