### PR TITLE
Fixed issue with damaging potential entities

### DIFF
--- a/0-SCore/Scripts/Entities/EntityAliveSDX.cs
+++ b/0-SCore/Scripts/Entities/EntityAliveSDX.cs
@@ -787,21 +787,13 @@ public class EntityAliveSDX : EntityTrader
 
     public override int DamageEntity(DamageSource _damageSource, int _strength, bool _criticalHit, float _impulseScale)
     {
-        if (EntityUtilities.IsAnAlly(entityId, _damageSource.getEntityId()))
-            return 0;
-
         if (EntityUtilities.GetBoolValue(entityId, "Invulnerable"))
             return 0;
 
         if (Buffs.HasBuff("buffInvulnerable"))
             return 0;
 
-        // If the damage source is a living entity, and it's not an enemy, don't take damage.
-        // Note - this also ignores explosion damage if the explosion is caused by friendly fire.
-        // If people find that unacceptable, we could check EnumGameStats.PlayerKillingMode, or
-        // create a feature block flag, or something along those lines.
-        var entity = world.GetEntity(_damageSource.getEntityId()) as EntityAlive;
-        if (entity != null && !SCoreUtils.IsEnemy(this, entity))
+        if (!SCoreUtils.CanDamage(this, world.GetEntity(_damageSource.getEntityId())))
             return 0;
 
         // If we are being attacked, let the state machine know it can fight back


### PR DESCRIPTION
The previous code would not allow entities to be damaged if they were not an enemy. That included a faction check, which meant that players could not damage entities at all unless they were in a "Hate" relationship with that entity's faction.

The new code changes this check so that entities can be damaged by _merely potential_ enemies.

There are also new changes to handle multiplayer. If the target, leader, or target's leader are players, it calls the vanilla FriendlyFireCheck code that takes multiplayer settings into account.

It also calls the new code to check if entities can see through blocks that collide with their weapons/ammo (missed when merging by hand).