### PR TITLE
IsAlly will no longer rely on leaders

### DIFF
--- a/0-SCore/Scripts/UtilityAI/Filters/UAIFilterIsAlly.cs
+++ b/0-SCore/Scripts/UtilityAI/Filters/UAIFilterIsAlly.cs
@@ -2,7 +2,6 @@
 {
     /// <summary>
     /// Filter that tests whether the target entity is an ally of the targeting entity.
-    /// An ally is an entity that is your leader/owner, or has the same leader/owner as you.
     /// </summary>
     public class UAIFilterIsAlly : IUAITargetFilter<Entity>
     {
@@ -15,8 +14,9 @@
 
         public bool Test(Entity target)
         {
-            // TODO should we also include entities that are of the same faction?
-            return SCoreUtils.IsAlly(self, target);
+            // We can't use IsAlly because that only returns true if you have the same leader as
+            // the target, so will always fail for NPCs that don't have a leader.
+            return SCoreUtils.IsFriend(self, target);
         }
     }
 }

--- a/0-SCore/Scripts/UtilityAI/UAISCoreUtils.cs
+++ b/0-SCore/Scripts/UtilityAI/UAISCoreUtils.cs
@@ -169,6 +169,28 @@ namespace UAI
         }
 
         /// <summary>
+        /// Tests to see if the target entity is a friend. A "friend" is defined as yourself,
+        /// your leader, allies (those who share a leader), and entities in "loved" factions
+        /// (including members of your own faction, if not overridden by your leader).
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="target"></param>
+        /// <returns></returns>
+        public static bool IsFriend(EntityAlive self, Entity target)
+        {
+            if (!(target is EntityAlive targetEntity))
+                return false;
+
+            if (targetEntity.IsDead())
+                return false;
+
+            if (self.entityId == target.entityId)
+                return true;
+
+            return !IsEnemyOrPotentialEnemy(self, target, true);
+        }
+
+        /// <summary>
         /// This method checks to see if damage, presumably caused by another entity,
         /// is allowed to actually do damage to the checking entity.
         /// </summary>


### PR DESCRIPTION
The UAIFilterIsAlly code called SCoreUtils.IsAlly, but that only checks if the target has the same leader as yourself. It didn't include the entity itself (nor members of its own faction), so it always failed if the NPC didn't have a leader.

Changed by creating a new method, SCoreUtils.IsFriend, that includes itself, and anything that is not a "potential enemy" according to SCoreUtils.IsEnemyOrPotentialEnemy.

This should fix NPCMOD-SP-0024 in the NPCMod bug list.