### PR TITLE
Targeting fixes

### DIFF
--- a/0-SCore/Harmony/NPCFeatures/EntityAlivePatcher.cs
+++ b/0-SCore/Harmony/NPCFeatures/EntityAlivePatcher.cs
@@ -48,13 +48,13 @@ namespace Harmony.NPCFeatures
         [HarmonyPatch("DamageEntity")]
         public class EntityAliveDamageEntity
         {
-            private static bool Prefix(global::EntityAlive __instance, DamageSource _damageSource)
+            private static bool Prefix(global::EntityAlive __instance, ref int __result, DamageSource _damageSource)
             {
-                // Check if this feature is enabled.
-                if (!Configuration.CheckFeatureStatus(AdvFeatureClass, Feature))
-                    return true;
+                // I'm commenting this out, since it is now the expected behavior for all NPCs.
+                //if (!Configuration.CheckFeatureStatus(AdvFeatureClass, Feature))
+                //    return true;
 
-                if (EntityUtilities.IsAnAlly(__instance.entityId, _damageSource.getEntityId()))
+                if (!UAI.SCoreUtils.CanDamage(__instance, __instance.world.GetEntity(_damageSource.getEntityId())))
                     return false;
 
                 return true;

--- a/0-SCore/Scripts/Entities/EntityAliveSDX.cs
+++ b/0-SCore/Scripts/Entities/EntityAliveSDX.cs
@@ -871,10 +871,8 @@ public class EntityAliveSDX : EntityTrader
 
     public override bool CanDamageEntity(int _sourceEntityId)
     {
-        if (EntityUtilities.IsAnAlly(entityId, _sourceEntityId))
-            return false;
-
-        return true;
+        // If they can't damage us, we can't damage them.
+        return SCoreUtils.CanDamage(this, world.GetEntity(_sourceEntityId));
     }
 
     public override void ProcessDamageResponseLocal(DamageResponse _dmResponse)

--- a/0-SCore/Scripts/Entities/EntityUtilities.cs
+++ b/0-SCore/Scripts/Entities/EntityUtilities.cs
@@ -1461,9 +1461,9 @@ public static class EntityUtilities
             return false;
         }
 
-        var myRelationship = FactionManager.Instance.GetRelationshipTier(myEntity, entity);
+        var myRelationship = GetFactionRelationship(myEntity, entity);
         DisplayLog(" CheckFactionForEnemy: " + myRelationship);
-        if (myRelationship == FactionManager.Relationship.Hate)
+        if (myRelationship < (float)FactionManager.Relationship.Dislike)
         {
             DisplayLog(" I hate this entity: " + entity);
             return false;
@@ -1471,6 +1471,27 @@ public static class EntityUtilities
 
         DisplayLog(" My relationship with this " + entity + " is: " + myRelationship);
         return true;
+    }
+
+    /// <summary>
+    /// Reliably gets the faction relationship between yourself and a target.
+    /// </summary>
+    /// <param name="self"></param>
+    /// <param name="target"></param>
+    /// <returns></returns>
+    public static float GetFactionRelationship(EntityAlive self, EntityAlive target)
+    {
+        var selfCheckTarget = FactionManager.Instance.GetRelationshipValue(self, target);
+
+        // This is needed because if you don't have a faction entry in npcs.xml, the vanilla code
+        // will return "neutral." In this case, we assume the target does have a faction entry,
+        // and check ourselves against their entry.
+        if (selfCheckTarget != (float)FactionManager.Relationship.Neutral)
+        {
+            return selfCheckTarget;
+        }
+
+        return FactionManager.Instance.GetRelationshipValue(target, self);
     }
 
     public static bool CheckForBuff(int EntityID, string strBuff)

--- a/0-SCore/Scripts/UtilityAI/UAISCoreUtils.cs
+++ b/0-SCore/Scripts/UtilityAI/UAISCoreUtils.cs
@@ -1,4 +1,4 @@
-﻿using GamePath;
+using GamePath;
 using Platform;
 using System;
 using System.Collections.Generic;
@@ -249,6 +249,10 @@ namespace UAI
 
             if (theirLeader != null)
             {
+                // Checks if we are allies: share a leader, or are their leader.
+                if (IsAlly(target, self))
+                    return false;
+
                 // If their leader is a player, perform a friendly fire check against us.
                 // (We already did a friendly fire check when both leaders are players.)
                 if (theirLeader is EntityPlayer theirPlayer && self is EntityPlayer us)
@@ -274,7 +278,7 @@ namespace UAI
             if (revengeTarget != null && revengeTarget.entityId == target.entityId)
                 return true;
 
-            var relationship = FactionManager.Instance.GetRelationshipValue(targetedEntity, targetingEntity );
+            var relationship = EntityUtilities.GetFactionRelationship(targetedEntity, targetingEntity);
 
             // A faction relationship value less than 800 (Love) means they are a potential enemy.
             // A faction relationship value less than 200 (Dislike) means they are an actual enemy.


### PR DESCRIPTION
* Harmony prefix to EntityAlive.DamageEntity now uses SCoreUtils.CanDamage, because IsAnAlly will fail if the checking entity is the leader of the damaging entity
* EntityAliveSDX.CanDamageEntity now uses SCoreUtils.CanDamage as well
* Added EntityUtilities.GetFactionRelationship to deal with entities (like players) that don't have faction entries in npcs.xml
* SCoreUtils.IsEnemyOrPotentialEnemy now checks to see if you are the target's leader (when it has one)