### PR TITLE
Fixed GetFactionRelationship

### DIFF
--- a/0-SCore/Scripts/Entities/EntityUtilities.cs
+++ b/0-SCore/Scripts/Entities/EntityUtilities.cs
@@ -1493,11 +1493,11 @@ public static class EntityUtilities
         var selfFaction = FactionManager.Instance.GetFaction(self.factionId);
         if (selfFaction != null && !selfFaction.IsPlayerFaction)
         {
-            relationship = selfFaction.GetRelationship(target.factionId);
+            relationship = FactionManager.Instance.GetRelationshipValue(self, target);
         }
         else
         {
-            // The self doesn't have a full faction, or it's a player. Let's flip it.
+            // The self is an entity without a faction property in its entity class XML, or it's a player. Let's flip it.
             selfFaction = FactionManager.Instance.GetFaction(target.factionId);
             if (selfFaction != null)
                 relationship = selfFaction.GetRelationship(self.factionId);


### PR DESCRIPTION
Hopefully for the last time this time.

Our previous understanding was incorrect. Here's how it actually works:

* If self is a player, it will have a non-null faction, but its relationships with all other factions will be 400 (Neutral), so we can't use their faction to accurately determine relationships.
* If self is an NPC with a faction property (or inherited faction property) in its entity class XML, it will have a non-null, named faction as defined in npcs.xml. However, if npcs.xml does not define a relationship to its own faction - and so far, none do - then its relationship to its own faction will be whatever "*" is in npc.xml (and not "Love").
* If self is an NPC without a faction property in its entity class XML (or inherited faction property), it will have a faction ID of zero. This is whatever faction was defined first in npc.xml, In vanilla this is the "none" faction.

You can see this logic at work in EntityAlive.CopyPropertiesFromEntityClass.

For cases where the entity is an NPC, and thus has a named faction from npc.xml, we should use FactionManager.GetRelationshipValue. That accounts for cases where the other entity shares its faction. It also accurately returns its relationship to the player, since the player faction is not null.

For players, we can use the other entity faction's GetRelationship method, which simply returns what is in the internal Relationships array and doesn't do any logic or verification.