### PR TITLE
Entity will only bypass activation commands if target can be damaged

### DIFF
--- a/0-SCore/Scripts/Entities/EntityAliveSDX.cs
+++ b/0-SCore/Scripts/Entities/EntityAliveSDX.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Class: EntityAliveSDX
  * Author:  sphereii 
  * Category: Entity
@@ -307,7 +307,8 @@ public class EntityAliveSDX : EntityTrader
         if (!EntityUtilities.IsHuman(entityId)) return new EntityActivationCommand[0];
 
         // do we have an attack or revenge target? don't have time to talk, bro
-        if (EntityUtilities.GetAttackOrRevengeTarget(entityId) != null) return new EntityActivationCommand[0];
+        var target = EntityUtilities.GetAttackOrRevengeTarget(entityId);
+        if (target != null && EntityTargetingUtilities.CanDamage(this, target)) return new EntityActivationCommand[0];
 
         return new[] 
         {


### PR DESCRIPTION
This allows friendly entities spawned with the player as their attack target (in "attack" sleeper volumes, quest actions, etc.) to interact with the player.