### PR TITLE
New feature flag for all entities using faction-based targeting

### DIFF
--- a/0-SCore/Config/blocks.xml
+++ b/0-SCore/Config/blocks.xml
@@ -113,6 +113,8 @@
         <!-- Tags that translate that the entity is alive and has a brain -->
         <property name="FactionRelationshipCVars" value="false" />
         <!-- Enables the addition of faction relationship cvars (see FactionRelationshipCVars.cs)  -->
+        <property name="AllEntitiesUseFactionTargeting" value="false" />
+        <!-- If true, all entities in the game use faction-based targeting -->
       </property>
 
       <!-- Allow themed settings to be applied: See Harmony/Atmosphere/-->

--- a/0-SCore/Harmony/NPCFeatures/EntityAlivePatcher.cs
+++ b/0-SCore/Harmony/NPCFeatures/EntityAlivePatcher.cs
@@ -50,9 +50,9 @@ namespace Harmony.NPCFeatures
         {
             private static bool Prefix(global::EntityAlive __instance, ref int __result, DamageSource _damageSource)
             {
-                // I'm commenting this out, since it is now the expected behavior for all NPCs.
-                //if (!Configuration.CheckFeatureStatus(AdvFeatureClass, Feature))
-                //    return true;
+                // New feature flag, specific to this feature.
+                if (!Configuration.CheckFeatureStatus(AdvFeatureClass, "AllEntitiesUseFactionTargeting"))
+                    return true;
 
                 if (!EntityTargetingUtilities.CanTakeDamage(__instance, __instance.world.GetEntity(_damageSource.getEntityId())))
                     return false;


### PR DESCRIPTION
The new XML property should default to false, or else anyone who installs SCore without NPCCore will get a broken game.

NPCCore will need to change this value.