### PR TITLE
EAITarget.check patch checks feature flag before doing faction check

### DIFF
--- a/0-SCore/Harmony/EAI/EAITarget.cs
+++ b/0-SCore/Harmony/EAI/EAITarget.cs
@@ -33,6 +33,11 @@ namespace Harmony.EAI
                 return;
             }
 
+            // This patches the check for all entities, so if we're not supposed to use faction
+            // targeting for everything, stop now. Otherwise, do the faction check.
+            if (!Configuration.CheckFeatureStatus("AdvancedNPCFeatures", "AllEntitiesUseFactionTargeting"))
+                return;
+
             var myRelationship = FactionManager.Instance.GetRelationshipTier(__instance.theEntity, _e);
             switch (myRelationship)
             {


### PR DESCRIPTION
This should fix issues with targeting if SCore is installed but NPCCore is not.

For example, before this change, bears could not attack players: they are in the animal faction, which is neutral to players in vanilla.