### PR TITLE
Fixes for NPCMOD-SP-0038 and NPCMOD-DEDI-0007

### DIFF
--- a/0-SCore/Scripts/Entities/EntityAliveSDX.cs
+++ b/0-SCore/Scripts/Entities/EntityAliveSDX.cs
@@ -336,7 +336,9 @@ public class EntityAliveSDX : EntityTrader
         // Don't allow interaction with a Hated entity
         if (EntityTargetingUtilities.IsEnemy(this, _entityFocusing)) return false;
 
-        if (EntityUtilities.GetAttackOrRevengeTarget(entityId) != null) return false;
+        // do we have an attack or revenge target? don't have time to talk, bro
+        var target = EntityUtilities.GetAttackOrRevengeTarget(entityId);
+        if (target != null && EntityTargetingUtilities.CanDamage(this, target)) return false;
 
         // Look at the entity that is talking to you.
         SetLookPosition(_entityFocusing.getHeadPosition());


### PR DESCRIPTION
* Changed EntityAliveSDX.OnEntityActivated to not activate only if the revenge target can be damaged (same logic as GetActivationCommands)
* Modified EntityTargetingUtilities.CanDamage so that "player friendly fire" settings are always checked, not just when the entity or its target is a player