### PR TITLE
Performance improvements and small bug fixes (#1)

### DIFF
--- a/0-SCore/Scripts/Entities/EntityTargetingUtilities.cs
+++ b/0-SCore/Scripts/Entities/EntityTargetingUtilities.cs
@@ -167,8 +167,23 @@ public static class EntityTargetingUtilities
         if (targetEntity.IsDead())
             return false;
 
-        // If we can't even damage it, no sense considering it an enemy.
-        if (!CanDamage(self, target))
+        // Don't start fights with vehicles.
+        if (IsDamageImmuneVehicle(self, target))
+            return false;
+
+        // Don't make enemies out of your followers, your leader, or fellow followers.
+        var myLeader = EntityUtilities.GetLeaderOrOwner(self.entityId);
+        if (IsAllyOfLeader(myLeader ?? self, target))
+            return false;
+
+        // If two players are involved (directly or as leaders), determine whether they or their
+        // followers can damage each other from the "Player Killing" setting.
+        // This is to make sure damage-immune entities are NOT enemies - the reverse is not true.
+        // Just because you can damage them does not make them enemies.
+        var selfPlayer = GetPlayerLeader(self, myLeader);
+        var targetPlayer = GetPlayerLeader(target);
+        // FriendlyFireCheck returns true if the players can damage each other
+        if (selfPlayer != null && targetPlayer != null && !selfPlayer.FriendlyFireCheck(targetPlayer))
             return false;
 
         // Our current revenge target is always an enemy.
@@ -176,7 +191,6 @@ public static class EntityTargetingUtilities
             return true;
 
         // If they are fighting my leader or allies, they're an enemy.
-        var myLeader = EntityUtilities.GetLeaderOrOwner(self.entityId);
         if (IsFightingFollowers(myLeader, target))
             return true;
 

--- a/0-SCore/Scripts/Entities/EntityUtilities.cs
+++ b/0-SCore/Scripts/Entities/EntityUtilities.cs
@@ -888,6 +888,10 @@ public static class EntityUtilities
         var leader = GetLeader(EntityID);
         if (leader == null)
             leader = GetOwner(EntityID);
+
+        // If we acquired a leader again, cache it.
+        if (leader != null)
+            SphereCache.LeaderCache[EntityID] = leader;
      
         return leader;
     }

--- a/0-SCore/Scripts/Features/AdvLogging.cs
+++ b/0-SCore/Scripts/Features/AdvLogging.cs
@@ -24,12 +24,12 @@
             Log.Out($"{AdvFeatureClass} :: {Feature} :: {strDisplay}");
     }
 
-    public static bool LogEnabled(string AdvFeatureClass, string strDisplay)
+    public static bool LogEnabled(string AdvFeatureClass)
     {
         return Configuration.CheckFeatureStatus(AdvFeatureClass);
     }
 
-    public static bool LogEnabled(string AdvFeatureClass, string Feature, string strDisplay)
+    public static bool LogEnabled(string AdvFeatureClass, string Feature)
     {
         return Configuration.CheckFeatureStatus(AdvFeatureClass, Feature);
     }

--- a/0-SCore/Scripts/UtilityAI/UAISCoreUtils.cs
+++ b/0-SCore/Scripts/UtilityAI/UAISCoreUtils.cs
@@ -270,9 +270,10 @@ namespace UAI
 
         public static bool IsEnemyNearby(Context _context, float distance = 20f)
         {
-            var revengeTarget = EntityUtilities.GetAttackOrRevengeTarget(_context.Self.entityId);
-            if ( revengeTarget)
-                if (EntityTargetingUtilities.IsEnemy(_context.Self, revengeTarget)) return true;
+            // Do we have a revenge target at any distance? If so, stay paranoid.
+            var revengeTarget = _context.Self.GetRevengeTarget();
+            if (revengeTarget && !EntityTargetingUtilities.ShouldForgiveDamage(_context.Self, revengeTarget))
+                return true;
 
             var nearbyEntities = new List<Entity>();
 
@@ -286,15 +287,12 @@ namespace UAI
                 if (x == null) continue;
                 if (x == _context.Self) continue;
                 if (x.IsDead()) continue;
-         
+
                 // Check to see if they are our enemy first, before deciding if we should see them.
                 if (!EntityTargetingUtilities.IsEnemy(_context.Self, x)) continue;
 
-                //// Can we see them?
-                if (!SCoreUtils.CanSee(_context.Self, x, distance))
-                    continue;
-
-
+                // Can we see them?
+                if (!SCoreUtils.CanSee(_context.Self, x, distance)) continue;
 
                 // Otherwise they are an enemy.
                 return true;


### PR DESCRIPTION
* Refactored EntityTargetingUtilities.IsEnemy to remove calls to CanDamage, reducing redundant checks, improving performance
* If EntityUtilities.GetLeaderOrOwner needs to acquire the leader from expensive calls, the leader is cached automatically (doesn't rely on callers invoking SetLeaderAndOwner)
* Removed last string param from both versions of AdvLogging.LogEnabled (was causing callers that passed AdvFeatureClass, Feature to use the overload where Feature would be considered strDisplay)
* SCoreUtils.IsEnemyNearby uses revenge target directly for initial "revenge target" check, rather than using either the attack or revenge target (the attack target may not be set by UAI, but it is set in sleeper volumes, quest spawns, etc.)
* Since IsEnemyNearby now uses revenge targets directly, it can use the more lightweight ShouldForgiveDamage method, rather than IsEnemy, improving performance