### PR TITLE
Redo animals faction fix, change damage faction relationship to "dislike" or below

### DIFF
--- a/0-SCore/Harmony/MiniTurret/shouldIgnoreTarget.cs
+++ b/0-SCore/Harmony/MiniTurret/shouldIgnoreTarget.cs
@@ -21,7 +21,8 @@ namespace SCore.Harmony.MiniTurret
             if (!__result)
             {
                 // Check the NPC faction to the player. This needs to be done as the player doesn't have a faction as defined in npc.xml
-                if (EntityUtilities.CheckFaction(_target.entityId,entity))
+                // But if this is an enemy using the "animals" faction, we can't do the faction check.
+                if (!EntityTargetingUtilities.IsEnemyInAnimalsFaction(_target) && EntityUtilities.CheckFaction(_target.entityId,entity))
                 {
                     __result = true;
                     return;

--- a/0-SCore/Scripts/Entities/EntityTargetingUtilities.cs
+++ b/0-SCore/Scripts/Entities/EntityTargetingUtilities.cs
@@ -10,12 +10,6 @@ using UnityEngine;
 public static class EntityTargetingUtilities
 {
     /// <summary>
-    /// The name of the cvar to check, to see if players can damage NPCs in friendly factions.
-    /// If this cvar is absent or zero, they cannot.
-    /// </summary>
-    public static readonly string DamageFriendliesCVarName = "varNPCModDamageFriendlies";
-
-    /// <summary>
     /// <para>
     /// Determines whether you can damage the target.
     /// </para>
@@ -29,34 +23,37 @@ public static class EntityTargetingUtilities
     /// <returns></returns>
     public static bool CanDamage(EntityAlive self, Entity target)
     {
-        // Enemy animals can not follow these rules.
-        if (IsEnemyInAnimalsFaction(self))
-            return self.CanDamageEntity(target.entityId);
-
         // Don't damage vehicles if they are immune.
         if (IsDamageImmuneVehicle(self, target))
             return false;
 
-        // If you're a player, check according to player rules.
-        if (self is EntityPlayer me)
-            return PlayerCanDamage(me, target);
-
+        // Don't damage your leader or fellow followers.
         var myLeader = EntityUtilities.GetLeaderOrOwner(self.entityId);
-
-        // If your leader is a player, check according to their rules.
-        if (myLeader is EntityPlayer playerLeader)
-            return PlayerCanDamage(playerLeader, target);
-
-        // Don't damage your (non-player) leader or fellow followers.
         if (IsAllyOfLeader(myLeader, target))
             return CanDamageAlly(self, target);
 
-        // You can always damage your revenge target, since they hit first.
+        // If two players are involved (directly or as leaders), determine whether they or their
+        // followers can damage each other from the "Player Killing" setting.
+        var selfPlayer = GetPlayerLeader(self, myLeader);
+        var targetPlayer = GetPlayerLeader(target);
+        if (selfPlayer != null && targetPlayer != null)
+        {
+            // FriendlyFireCheck returns true if the players can damage each other
+            return selfPlayer.FriendlyFireCheck(targetPlayer);
+        }
+
+        // If you are a player, don't damage your followers. Everyone else is on the table.
+        if (self is EntityPlayer)
+        {
+            return IsAlly(target, self) ? CanDamageAlly(target, self) : true;
+        }
+
+        // You can always damage your revenge target, even if it's a player (since they hit first).
         if (IsCurrentRevengeTarget(self, target))
             return true;
 
         // Otherwise, if the target is a player, you can only damage them if you or your
-        // (non-player) leader hate them.
+        // (not necessarily player) leader hate them.
         if (target is EntityPlayer)
         {
             return myLeader == null
@@ -68,7 +65,7 @@ public static class EntityTargetingUtilities
         if (IsFightingFollowers(myLeader, target))
             return true;
 
-        // If you have a (non-player) leader, check friendly fire using their faction.
+        // If you have a leader, check friendly fire using their faction.
         // In all other cases, use the faction relationship between yourself and the target.
         return myLeader == null
             ? !IsFriendlyFireByFaction(self, target)
@@ -196,14 +193,6 @@ public static class EntityTargetingUtilities
         // If they are fighting my leader or allies, they're an enemy.
         if (IsFightingFollowers(myLeader, target))
             return true;
-
-        // If it's an enemy animal, we can't use faction targeting. Instead, test to see if it's
-        // the attack target. (We considered the revenge target, above.)
-        if (IsEnemyInAnimalsFaction(self))
-        {
-            var attackTarget = self.GetAttackTarget();
-            return attackTarget.entityId == target.entityId;
-        }
 
         // They are an enemy if we hate them, or if our leader hates them.
         return myLeader == null
@@ -349,52 +338,6 @@ public static class EntityTargetingUtilities
     }
 
     /// <summary>
-    /// This determines whether a player can damage a target.
-    /// </summary>
-    /// <param name="player">Player that potentially does damage.</param>
-    /// <param name="target">Potential damage target.</param>
-    /// <returns></returns>
-    public static bool PlayerCanDamage(EntityPlayer player, Entity target)
-    {
-        // If this isn't a player, assume damage - probably wrong but better than an NRE
-        if (player == null)
-        {
-            Debug.LogWarning($"PlayerCanDamage called with non-player: player=null, target={target}");
-            return true;
-        }
-
-        // We don't need to do all these checks if the target isn't an NPC
-        if (!(target is EntityNPC npc))
-            return target.CanDamageEntity(player.entityId);
-
-        // Don't damage your followers.
-        if (IsAlly(npc, player))
-            return CanDamageAlly(player, npc);
-
-        // If it's a follower of another player, check friendly fire according to the settings.
-        var targetPlayer = GetPlayerLeader(npc);
-        if (targetPlayer != null)
-        {
-            // FriendlyFireCheck returns true if the players can damage each other.
-            return player.FriendlyFireCheck(targetPlayer);
-        }
-
-        // You can damage them if they are fighting you or your followers (they hit first).
-        if (IsFightingFollowers(player, npc))
-            return true;
-
-        // If we have the "damage friendlies" cvar, all bets are off.
-        // GetCustomVar also sets the custom var if it doesn't exist; avoid that situation.
-        if (player.Buffs.HasCustomVar(DamageFriendliesCVarName)
-            && player.Buffs.GetCustomVar(DamageFriendliesCVarName) > 0)
-            return true;
-
-        // Without that cvar, neutral or higher NPCs should not take damage.
-        var relationship = EntityUtilities.GetFactionRelationship(npc, player);
-        return relationship < (int)FactionManager.Relationship.Neutral;
-    }
-
-    /// <summary>
     /// Determines whether you should <em>immediately</em> forgive any damage that is taken from
     /// the target entity, so they are never considered a revenge target.
     /// </summary>
@@ -457,21 +400,6 @@ public static class EntityTargetingUtilities
             return false;
 
         return targetLeader.entityId == leader.entityId;
-    }
-
-    /// <summary>
-    /// Returns true if the entity is an enemy type that is using the vanilla "animals" faction.
-    /// That faction is neutral to all, so cannot target enemies based on faction standing.
-    /// </summary>
-    /// <param name="entity"></param>
-    /// <returns></returns>
-    private static bool IsEnemyInAnimalsFaction(Entity entity)
-    {
-        if (!(entity is EntityEnemy enemy))
-            return false;
-
-        var faction = FactionManager.Instance.GetFaction(enemy.factionId);
-        return faction?.Name == "animals";
     }
 
     /// <summary>


### PR DESCRIPTION
This reverts changes from the last pull request, and re-implements its features in a way that involves fewer code changes, and hopefully will not crash the game.

It also should fix an issue where player junk turrets/sledges will not target enemy animals, if SCore is installed by itself into a vanilla game (without NPC Core).

The "damage relationship" cvar has been renamed, and now holds the actual relationship value (it's no longer just a flag). If the relationship does not meet or exceed this value, the entity can be damaged.