### PR TITLE
Quick fix for NPCMOD-SP-0064

### DIFF
--- a/0-SCore/Scripts/Entities/EntityUtilities.cs
+++ b/0-SCore/Scripts/Entities/EntityUtilities.cs
@@ -711,7 +711,12 @@ public static class EntityUtilities
         {
             if (currentEntity.Buffs.HasCustomVar("Leader"))
             {
-                leader = GameManager.Instance.World.GetEntity((int)currentEntity.Buffs.GetCustomVar("Leader"));
+                int leaderId = (int)currentEntity.Buffs.GetCustomVar("Leader");
+                // This is a guard against some code, somewhere, getting the cvar value without
+                // checking to see if it exists first. If so, the cvar exists with a value of 0.
+                if (leaderId > 0)
+                    leader = GameManager.Instance.World.GetEntity(leaderId);
+
                 // Something happened to our leader.
                 if (leader == null)
                 {
@@ -819,7 +824,13 @@ public static class EntityUtilities
         if (myEntity == null) return null;
 
         if (myEntity.Buffs.HasCustomVar("Owner"))
-            leader = GameManager.Instance.World.GetEntity((int)myEntity.Buffs.GetCustomVar("Owner"));
+        {
+            int leaderId = (int)myEntity.Buffs.GetCustomVar("Owner");
+            // This is a guard against some code, somewhere, getting the cvar value without
+            // checking to see if it exists first. If so, the cvar exists with a value of 0.
+            if (leaderId > 0)
+                leader = GameManager.Instance.World.GetEntity(leaderId);
+        }
 
         return leader;
     }


### PR DESCRIPTION
Somewhere in the code, something is trying to get either the "Leader" or "Owner" cvar value, without checking to see if it exists first. (I could not track down where.) When this happens, the cvar is created if it doesn't exist, and set with the value of zero.

When doing a playthrough test of a prefab from the prefab builder, the world includes a test trader. That trader happens to have the entity ID of zero.

As a result, all NPCs in test playthroughs will have that trader as their leader, and won't attack the player.

This fix involves ignoring the value of zero for leader and owner IDs.