### PR TITLE
Fix for the "infinite harvest bug"

### DIFF
--- a/0-SCore/Harmony/NPCFeatures/EntityAlivePatcher.cs
+++ b/0-SCore/Harmony/NPCFeatures/EntityAlivePatcher.cs
@@ -104,14 +104,27 @@ namespace Harmony.NPCFeatures
         [HarmonyPatch("Hit")]
         public class ItemActionAttackHit
         {
-            private static bool Prefix(ItemActionAttack __instance, WorldRayHitInfo hitInfo, int _attackerEntityId)
+            private static bool Prefix(
+                ItemActionAttack __instance,
+                WorldRayHitInfo hitInfo,
+                int _attackerEntityId,
+                ItemActionAttack.AttackHitInfo _attackDetails)
             {
                 if (hitInfo?.tag == null) return false;
 
                 var entity = ItemActionAttack.FindHitEntityNoTagCheck(hitInfo, out var text3);
                 if (entity == null) return true;
 
-                return !EntityUtilities.IsAnAlly(entity.entityId, _attackerEntityId);
+                if (EntityUtilities.IsAnAlly(entity.entityId, _attackerEntityId))
+                {
+                    // This prevents the "infinite harvest bug"
+                    _attackDetails.bBlockHit = false;
+                    _attackDetails.bHarvestTool = false;
+                    _attackDetails.itemsToDrop = null;
+
+                    return false;
+                }
+                return true;
             }
         }
 


### PR DESCRIPTION
It turns out the culprit was `ItemActionDynamic.hitTarget` which populates the `AttackHitInfo` with a list of resources. This method is called by both `ItemActionDynamicMelee.Raycast` and by `ItemActionDynamicMelee.GrazeCast`.

Unfortunately the Harmony patch is still needed; without it, you can damage your hires.