### PR TITLE
Revenge targets not set on player allies; fixed bounds issue

### DIFF
--- a/0-SCore/Scripts/Entities/EntityTargetingUtilities.cs
+++ b/0-SCore/Scripts/Entities/EntityTargetingUtilities.cs
@@ -190,6 +190,41 @@ public static class EntityTargetingUtilities
     }
 
     /// <summary>
+    /// Determines whether yourself and the target entity are in allied parties.
+    /// You are in allied parties if:
+    /// <list type="bullet">
+    /// <item>the target is your leader</item>
+    /// <item>you are the target's leader</item>
+    /// <item>
+    /// you and your target both have player leaders, and those players can't damage each other
+    /// according to the "Player Killing" setting
+    /// </item>
+    /// </list>
+    /// Factions are not considered.
+    /// </summary>
+    /// <param name="self"></param>
+    /// <param name="targetEntity"></param>
+    /// <returns></returns>
+    public static bool IsAllyOfParty(Entity self, Entity targetEntity)
+    {
+        if (self == null || targetEntity == null)
+            return false;
+
+        // Don't assume either entity's leader is a player for this check
+        var selfLeader = EntityUtilities.GetLeaderOrOwner(self.entityId) ?? self;
+        var targetLeader = EntityUtilities.GetLeaderOrOwner(targetEntity.entityId) ?? targetEntity;
+
+        if (selfLeader.entityId == targetLeader.entityId)
+            return true;
+
+        // FriendlyFireCheck returns true if friendly fire is allowed
+        if (selfLeader is EntityPlayer selfPlayer && targetLeader is EntityPlayer targetPlayer)
+            return !selfPlayer.FriendlyFireCheck(targetPlayer);
+
+        return false;
+    }
+
+    /// <summary>
     /// Returns true if you consider the target to be your enemy.
     /// </summary>
     /// <param name="self"></param>

--- a/0-SCore/Scripts/Quests/QuestActionSetRevengeTargetsSDX.cs
+++ b/0-SCore/Scripts/Quests/QuestActionSetRevengeTargetsSDX.cs
@@ -21,7 +21,8 @@ using UnityEngine;
 /// </para>
 /// 
 /// <para>
-/// Revenge targets will be set on all living entities in range, except for player entities.
+/// Revenge targets will be set on all living entities in range, except for player entities,
+/// entities that the player has hired, or the hires of other players that are allies.
 /// Only entities that are awake will have their revenge targets set.
 /// </para>
 /// 
@@ -103,6 +104,11 @@ public class QuestActionSetRevengeTargetsSDX : BaseQuestAction
             if (entity is EntityPlayer)
                 continue;
 
+            // Don't set the revenge targets of entities hired by the quest owner,
+            // or by entities hired by members of the quest owner's party
+            if (EntityTargetingUtilities.IsAllyOfParty(entity, ownerQuest.OwnerJournal.OwnerPlayer))
+                continue;
+
             var target = GetRandomTarget(targetEntities);
             entity.SetRevengeTarget(target);
             entity.SetRevengeTimer(REVENGE_TICKS);
@@ -127,7 +133,8 @@ public class QuestActionSetRevengeTargetsSDX : BaseQuestAction
                     location.y + size.y / 2f,
                     location.z + size.z / 2f);
 
-                return new Bounds(center, size);
+                // The bounds constructor shrinks the size vector in half, compensate here
+                return new Bounds(center, 2f * size);
             }
         }
         else if (!string.IsNullOrEmpty(Value) && !float.TryParse(Value, out distance))


### PR DESCRIPTION
The revenge targets were being set on all entities in bounds, including the player hires. This is now fixed, and in addition the revenge targets also will not be set on other players in the party, provided those players are protected from friendly fire.

To detect whether an entity is an ally of the player's party, I created a new `IsAllyOfParty` method in `EntityTargetingUtilities`. I did not change any existing methods so there should be no risk of breaking anything.

I also fixed an issue where the POI's full area was not covered (the `Bounds` constructor shrinks the `size` vector argument in half so only a quarter of the prefab was covered).