### PR TITLE
UAI tasks trigger alert, sense, and "give up" sounds

### DIFF
--- a/0-SCore/Scripts/UtilityAI/UAITaskAttackTargetEntitySDX.cs
+++ b/0-SCore/Scripts/UtilityAI/UAITaskAttackTargetEntitySDX.cs
@@ -32,6 +32,7 @@ namespace UAI
                 _context.Self.SetLookPosition( entityAlive.getHeadPosition());
                 var targetPosition = entityAlive.getHeadPosition();
                 _context.Self.RotateTo(targetPosition.x, targetPosition.y, targetPosition.y, 30f, 30f);
+                _context.Self.SleeperSupressLivingSounds = false;
                 _context.Self.SetAttackTarget(entityAlive, 1200);
             }
 

--- a/0-SCore/Scripts/UtilityAI/UAITaskMoveToInvestigate.cs
+++ b/0-SCore/Scripts/UtilityAI/UAITaskMoveToInvestigate.cs
@@ -11,7 +11,11 @@ namespace UAI
         public override void Update(Context _context)
         {
             if (SCoreUtils.IsBlocked(_context))
+            {
+                // We're giving up
+                _context.Self.PlayGiveUpSound();
                 this.Stop(_context);
+            }
 
             base.Update(_context);
         }
@@ -67,7 +71,14 @@ namespace UAI
 
             _context.ActionData.Started = true;
             _context.ActionData.Executing = true;
-            
+
+            // If we are investigating a new enemy, play the "sense" sound.
+            var entityAlive = UAIUtils.ConvertToEntityAlive(_context.ActionData.Target);
+            if (EntityUtilities.GetAttackOrRevengeTarget(_context.Self.entityId) != entityAlive
+                && EntityTargetingUtilities.IsEnemy(_context.Self, entityAlive))
+            {
+                _context.Self.PlayOneShot(_context.Self.soundSense);
+            }
         }
     }
 }

--- a/0-SCore/Scripts/UtilityAI/UAITaskMoveToTargetSDX.cs
+++ b/0-SCore/Scripts/UtilityAI/UAITaskMoveToTargetSDX.cs
@@ -15,6 +15,9 @@ namespace UAI
             // Reset crouch status to default
             SCoreUtils.SetCrouching(_context);
 
+            // If we're a sleeper, we can make sounds now
+            _context.Self.SleeperSupressLivingSounds = false;
+
             var entityAlive = UAIUtils.ConvertToEntityAlive(_context.ActionData.Target);
             if (entityAlive != null)
             {
@@ -22,6 +25,19 @@ namespace UAI
                 if (entityAlive.IsWalkTypeACrawl())
                     _position = entityAlive.getHeadPosition();
                 _context.Self.SetInvestigatePosition(_position, 1200);
+
+                var isEnemy = EntityTargetingUtilities.IsEnemy(_context.Self, entityAlive);
+
+                // If the target is a new enemy, play the "alert" sound.
+                if (isEnemy && EntityUtilities.GetAttackOrRevengeTarget(_context.Self.entityId) != entityAlive)
+                {
+                    _context.Self.PlayOneShot(_context.Self.GetSoundAlert());
+                }
+
+                // We don't set the attack target yet, but the game should know if we're
+                // approaching an enemy or player.
+                _context.Self.ApproachingEnemy = isEnemy;
+                _context.Self.ApproachingPlayer = entityAlive is EntityPlayer;
             }
 
             if (_context.ActionData.Target is Vector3 vector)


### PR DESCRIPTION
This is the minimum code needed to get those sounds working.

I did not alter the way the tasks handle setting the attack target. If that is done differently in the future, then the code in `UAITaskMoveToTargetSDX` can probably be changed, since setting the attack target also sets `ApproachingEnemy` and `ApproachingPlayer`. Those values determine whether the entity plays the "SoundRandom" sound, or the "SoundAlert" sound.