### PR TITLE
Move speed changes

### DIFF
--- a/0-SCore/Scripts/Entities/EntityEnemySDX.cs
+++ b/0-SCore/Scripts/Entities/EntityEnemySDX.cs
@@ -69,6 +69,26 @@ public class EntityEnemySDX : EntityEnemy, IEntityOrderReceiverSDX
         return flEyeHeight;
     }
 
+    public override float GetMoveSpeed()
+    {
+        return IsCrouching
+            ? EffectManager.GetValue(PassiveEffects.CrouchSpeed, null, moveSpeed, this)
+            : EffectManager.GetValue(PassiveEffects.WalkSpeed, null, moveSpeed, this);
+    }
+
+    public override float GetMoveSpeedAggro()
+    {
+        return IsBloodMoon
+            ? EffectManager.GetValue(PassiveEffects.RunSpeed, null, moveSpeedAggroMax, this)
+            : EffectManager.GetValue(
+                // Horde entities use WalkSpeed, but that messes up melee attacking. Luckily when
+                // an entity finds an attack target they're no longer considered part of a horde.
+                IsHordeZombie ? PassiveEffects.WalkSpeed : PassiveEffects.RunSpeed,
+                null,
+                moveSpeedAggro,
+                this);
+    }
+
     public override void PostInit()
     {
         base.PostInit();

--- a/0-SCore/Scripts/UtilityAI/UAISCoreUtils.cs
+++ b/0-SCore/Scripts/UtilityAI/UAISCoreUtils.cs
@@ -581,6 +581,13 @@ namespace UAI
         public static float SetSpeed(Context _context, bool panic = false)
         {
             var speed = _context.Self.GetMoveSpeed();
+            
+            // Entities spawned into hordes move at aggro speed, not normal move speed
+            if (_context.Self is EntityEnemy enemy && enemy.IsHordeZombie)
+            {
+                speed = enemy.GetMoveSpeedAggro();
+            }
+
             if (panic)
                 speed = _context.Self.GetMoveSpeedPanic();
 


### PR DESCRIPTION
* `EntityEnemySDX` overrides `GetMoveSpeed` and `GetMoveSpeedAggro` to fix issues with melee entities not running at the player when attacking
* `SCoreUtils.SetSpeed` now takes into account enemies spawned into hordes