### PR TITLE
EntityEnemy changes for animations and spawning into hordes

### DIFF
--- a/0-SCore/Harmony/Animation/AvatarController.cs
+++ b/0-SCore/Harmony/Animation/AvatarController.cs
@@ -72,7 +72,7 @@ namespace Harmony.Animation
             public static void Postfix(global::AvatarZombieController __instance,  global::EntityAlive ___entity)
             {
                 if ( ___entity == null) return;
-                if (___entity is not EntityAliveSDX entityAliveSdx) return;
+                if (___entity is not EntityAliveSDX && ___entity is not EntityEnemySDX) return;
                 if (___entity.IsFlyMode.Value) return;
                 
                 

--- a/0-SCore/Scripts/Entities/EntityEnemySDX.cs
+++ b/0-SCore/Scripts/Entities/EntityEnemySDX.cs
@@ -28,12 +28,11 @@ using Random = System.Random;
 /// </code>
 /// </example>
 /// </summary>
-public class EntityEnemySDX : EntityEnemy, IEntityOrderReceiverSDX
+public class EntityEnemySDX : EntityHuman, IEntityOrderReceiverSDX
 {
     public float flEyeHeight = -1f;
     public bool isAlwaysAwake;
     public Random random = new Random();
-    public ulong timeToDie;
 
 
     #region Interface Backing Fields
@@ -98,6 +97,9 @@ public class EntityEnemySDX : EntityEnemy, IEntityOrderReceiverSDX
         SetupAutoPathingBlocks();
     }
 
+    /// <summary>
+    /// Sets up the starting items. Copied from <see cref="EntityTrader.SetupStartingItems"/>.
+    /// </summary>
     protected virtual void SetupStartingItems()
     {
         for (var i = 0; i < itemsOnEnterGame.Count; i++)
@@ -135,22 +137,6 @@ public class EntityEnemySDX : EntityEnemy, IEntityOrderReceiverSDX
     public override void OnAddedToWorld()
     {
         base.OnAddedToWorld();
-        this.timeToDie = this.world.worldTime + 1800UL + (ulong)(22000f * this.rand.RandomFloat);
-        if (this.IsFeral && base.GetSpawnerSource() == EnumSpawnerSource.Biome)
-        {
-            int num = (int)SkyManager.GetDawnTime();
-            int num2 = (int)SkyManager.GetDuskTime();
-            int num3 = GameUtils.WorldTimeToHours(this.WorldTimeBorn);
-            if (num3 < num || num3 >= num2)
-            {
-                int num4 = GameUtils.WorldTimeToDays(this.world.worldTime);
-                if (GameUtils.WorldTimeToHours(this.world.worldTime) >= num2)
-                {
-                    num4++;
-                }
-                this.timeToDie = GameUtils.DayTimeToWorldTime(num4, num, 0);
-            }
-        }
 
         if (isAlwaysAwake)
         {

--- a/0-SCore/Scripts/UtilityAI/UAIConsiderationHasInvestigatePosition.cs
+++ b/0-SCore/Scripts/UtilityAI/UAIConsiderationHasInvestigatePosition.cs
@@ -1,0 +1,30 @@
+﻿namespace UAI
+{
+    /// <summary>
+    /// Utility AI task to determine if the target entity has an investigate position.
+    /// </summary>
+    public class UAIConsiderationHasInvestigatePosition : UAIConsiderationBase
+    {
+        public override float GetScore(Context _context, object target)
+        {
+            if (target is not EntityAlive entityAlive)
+                return 0f;
+
+            return entityAlive.HasInvestigatePosition ? 1f : 0f;
+        }
+    }
+
+    /// <summary>
+    /// Utility AI task to determine if the target entity does not have an investigate position.
+    /// </summary>
+    public class UAIConsiderationHasNoInvestigatePosition : UAIConsiderationBase
+    {
+        public override float GetScore(Context _context, object target)
+        {
+            if (target is not EntityAlive entityAlive)
+                return 0f;
+
+            return entityAlive.HasInvestigatePosition ? 0f : 1f;
+        }
+    }
+}

--- a/0-SCore/Scripts/UtilityAI/UAITaskApproachSpotSDX.cs
+++ b/0-SCore/Scripts/UtilityAI/UAITaskApproachSpotSDX.cs
@@ -1,0 +1,121 @@
+﻿namespace UAI
+{
+    /// <summary>
+    /// Utility AI task to approach a spot, as determined by the investigate position.
+    /// The name and functionality is based on <see cref="EAIApproachSpot"/>.
+    /// </summary>
+    public class UAITaskApproachSpotSDX : UAITaskBase
+    {
+        // Use the same feature class as EntityUtilities
+        private static readonly string AdvFeatureClass = "AdvancedNPCFeatures";
+
+        public override void Start(Context _context)
+        {
+            base.Start(_context);
+
+            if (!_context.Self.HasInvestigatePosition)
+            {
+                Stop(_context);
+                return;
+            }
+
+            if (_context.Self.IsSleeping)
+            {
+                ClearAndStop(_context);
+                return;
+            }
+
+            SCoreUtils.SetCrouching(_context);
+
+            _context.Self.moveHelper.CanBreakBlocks = false;
+
+            UpdatePath(_context);
+        }
+
+        public override void Stop(Context _context)
+        {
+            _context.Self.getNavigator().clearPath();
+
+            _context.Self.moveHelper.CanBreakBlocks = true;
+
+            base.Stop(_context);
+        }
+
+        public override void Update(Context _context)
+        {
+            base.Update(_context);
+
+            // If we're investigating, we can open doors
+            SCoreUtils.CheckForClosedDoor(_context);
+
+            // If the path is blocked, we need to clear the investigate position so the NPC
+            // doesn't try to keep going if the task is restarted
+            if (IsBlocked(_context))
+            {
+                AdvLogging.DisplayLog(
+                    AdvFeatureClass,
+                    $"{_context.Self} is blocked for {_context.Self.moveHelper.BlockedTime}");
+                _context.Self.PlayGiveUpSound();
+                ClearAndStop(_context);
+                return;
+            }
+
+            if (HasReachedDestination(_context))
+            {
+                AdvLogging.DisplayLog(
+                    AdvFeatureClass,
+                    $"{_context.Self} has reached destination: {_context.Self.InvestigatePosition}");
+                ClearAndStop(_context);
+                return;
+            }
+
+            if (NeedsPath(_context))
+            {
+                AdvLogging.DisplayLog(
+                    AdvFeatureClass,
+                    $"{_context.Self} needs path, finding one to {_context.Self.InvestigatePosition}");
+                UpdatePath(_context);
+            }
+        }
+
+        // We only want to clear the investigate position if we stopped ourselves, not if another
+        // task gained higher priority, so don't clear the investigate position in Stop()
+        private void ClearAndStop(Context context)
+        {
+            context.Self.ClearInvestigatePosition();
+            Stop(context);
+        }
+
+        private static bool HasReachedDestination(Context context)
+        {
+            // Use square magnitude, since it's computationally less expensive
+            return (context.Self.position - context.Self.InvestigatePosition).sqrMagnitude < 4;
+        }
+
+        private static bool IsBlocked(Context _context)
+        {
+            return _context.Self.moveHelper.IsBlocked
+                && _context.Self.moveHelper.BlockedTime > 0.35f;
+        }
+
+        private static bool NeedsPath(Context context)
+        {
+            return context.Self.getNavigator()?.noPathAndNotPlanningOne() ?? false;
+        }
+
+        private void UpdatePath(Context context)
+        {
+            var lookPosition = context.Self.InvestigatePosition;
+            lookPosition.y += 0.8f;
+            context.Self.SetLookPosition(lookPosition);
+
+            context.Self.FindPath(
+                // EAIApproachSpot uses World.FindSupportingBlockPos(InvestigatePosition), but if
+                // we do that we won't be able to check if we've reached that position.
+                context.Self.InvestigatePosition,
+                context.Self.GetMoveSpeedAggro(),
+                false,
+                null);
+        }
+    }
+}

--- a/0-SCore/Scripts/UtilityAI/UAITaskAttackTargetEntitySDX.cs
+++ b/0-SCore/Scripts/UtilityAI/UAITaskAttackTargetEntitySDX.cs
@@ -149,28 +149,28 @@ namespace UAI
                 return;
             }
 
-            var num = UAIUtils.DistanceSqr(_context.Self.position, position);
+            //var num = UAIUtils.DistanceSqr(_context.Self.position, position);
             var entityAliveSdx = _context.Self as EntityAliveSDX;
     
             // Check the range on the item action
             ItemActionRanged.ItemActionDataRanged itemActionData = null;
             var itemAction = _context.Self.inventory.holdingItem.Actions[_actionIndex];
-            var distance = ((itemAction != null) ? Utils.FastMax(0.8f, itemAction.Range) : 1.095f);
+            //var distance = ((itemAction != null) ? Utils.FastMax(0.8f, itemAction.Range) : 1.095f);
             if (itemAction is ItemActionRanged itemActionRanged)
             {
                 itemActionData = _context.Self.inventory.holdingItemData.actionData[_actionIndex] as ItemActionRanged.ItemActionDataRanged;
                 if (itemActionData != null)
                 {
-                    var range = itemActionRanged.GetRange(itemActionData);
-                    distance = Utils.FastMax(0.8f, range);
+                    //var range = itemActionRanged.GetRange(itemActionData);
+                    //distance = Utils.FastMax(0.8f, range);
                     
                     // Check if we are already running.
                     if (itemAction.IsActionRunning(itemActionData))
                         return;
                 }
             }
-            var minDistance = distance * distance;
-            var a = position - _context.Self.position;
+            //var minDistance = distance * distance;
+            //var a = position - _context.Self.position;
 
             //not within range ?
             // if (a.sqrMagnitude > minDistance)
@@ -196,7 +196,14 @@ namespace UAI
                     _context.Self.Attack(true);
                     break;
                 case 1:
-                    if (!_context.Self.Use(false)) return;
+                    // Use() doesn't trigger the weapon fire animation, do that here.
+                    // Trigger it now so the first call to Use() has the correct animation.
+                    _context.Self.emodel.avatarController.TriggerEvent("WeaponFire");
+                    if (!_context.Self.Use(false))
+                    {
+                        _context.Self.emodel.avatarController.CancelEvent("WeaponFire");
+                        return;
+                    }
                     _context.Self.Use(true);
                     break;
                 default:


### PR DESCRIPTION
* Harmony patch to `AvatarZombieController` now also applies for `EntityEnemySDX`
* `EntityEnemySDX` now descends from `EntityHuman` (solves issues and allows us to get rid of redundant code)
* `UAITaskAttackTargetEntitySDX` now explicitly sets the "WeaponFire" bool when using the ranged attack (index 1, a.k.a. "Use"), and accounts for the case where the call to `Use` fails
* New UAI Task: `UAITaskApproachSpot` - based on `EAIApproachSpot` to direct entities to their investigate positions (especially when spawned into hordes)
* New UAI Consideration: `UAIConsiderationHasInvestigatePosition` - returns 1 if the target entity has an investigate position, 0 otherwise. Needed for a new action in the basic NPC Utility AI that overrides the "Wander" action.