### PR TITLE
Remove the prompt to talk with enemy NPCs

### DIFF
--- a/0-SCore/Config/blocks.xml
+++ b/0-SCore/Config/blocks.xml
@@ -197,6 +197,9 @@
 				-->
 
 				<property name="DisplayCompanions" value="true" />
+
+				<property name="AdvancedEnemyNPCs" value="false" />
+				<!-- Set to true if some enemy NPCs are "advanced" NPCs that use EntityAliveSDX. -->
 			</property>
 
 			<!-- Allow themed settings to be applied: See Harmony/Atmosphere/-->

--- a/0-SCore/Harmony/PlayerFeatures/PlayerMoveControllerUpdate.cs
+++ b/0-SCore/Harmony/PlayerFeatures/PlayerMoveControllerUpdate.cs
@@ -22,5 +22,92 @@ namespace Harmony.PlayerFeatures
                         ___entityPlayerLocal.Buffs.RemoveBuff(buff.BuffName);
             return true;
         }
+
+        private static readonly string AdvancedFeatureClass = "AdvancedNPCFeatures";
+        private static readonly string AdvancedEnemyNPCsFeature = "AdvancedEnemyNPCs";
+
+        private static bool _initialized = false;
+        private static bool _enabled = false;
+
+        /// <summary>
+        /// Disables the "Press E to interact..." prompt if the NPC is an enemy.
+        /// This is only needed if some enemy NPCs use EntityAliveSDX.
+        /// </summary>
+        /// <param name="___entityPlayerLocal"></param>
+        /// <param name="___strTextLabelPointingTo"></param>
+        public static void Postfix(
+            EntityPlayerLocal ___entityPlayerLocal,
+            ref string ___strTextLabelPointingTo)
+        {
+            if (!_initialized)
+                Initialize();
+
+            if (!_enabled)
+                return;
+
+            if (!___entityPlayerLocal.IsAlive())
+                return;
+
+            var hitInfo = ___entityPlayerLocal.HitInfo;
+
+            // This is how the code determines if it's an entity that can be interacted with
+            if (!hitInfo.bHitValid ||
+                !hitInfo.tag.StartsWith("E_") ||
+                hitInfo.hit.distanceSq >= Constants.cCollectItemDistance * Constants.cCollectItemDistance)
+                return;
+
+            var rootTransform = GameUtils.GetHitRootTransform(hitInfo.tag, hitInfo.transform);
+            if (rootTransform == null)
+                return;
+
+            var entity = rootTransform.GetComponent<Entity>();
+            if (entity is not EntityNPC npc || !npc.IsAlive())
+                return;
+
+            // This is how the code determines if it's a trader/EntityAliveSDX (vs. a drone)
+            if (GameManager.Instance.World.GetTileEntity(npc.entityId) is not TileEntityTrader)
+                return;
+
+            // At this point we know it's a trader or EntityAliveSDX and that the "Press E..."
+            // prompt is to be shown; now determine if it's an enemy, and if so, hide the prompt
+            if (ShouldTalk(___entityPlayerLocal, npc))
+                return;
+
+            ___strTextLabelPointingTo = string.Empty;
+            XUiC_InteractionPrompt.SetText(___entityPlayerLocal.PlayerUI, null);
+        }
+
+        private static void Initialize()
+        {
+            _initialized = true;
+
+            _enabled = Configuration.CheckFeatureStatus(
+                AdvancedFeatureClass,
+                AdvancedEnemyNPCsFeature);
+
+            AdvLogging.DisplayLog(
+                AdvancedFeatureClass,
+                $"{AdvancedEnemyNPCsFeature} {(_enabled ? "en" : "dis")}abled");
+        }
+
+        /// <summary>
+        /// This is a specialized method, which basically returns false if the NPC is an enemy
+        /// of the player. We already know the entity types, that neither entity is dead or null,
+        /// and that a player can't have a leader, so we don't need to do all of the checks in
+        /// <see cref="EntityTargetingUtilities.IsEnemy(global::EntityAlive, Entity)"/>.
+        /// <param name="player"></param>
+        /// <param name="npc"></param>
+        /// <returns></returns>
+        private static bool ShouldTalk(EntityPlayerLocal player, EntityNPC npc)
+        {
+            if (EntityTargetingUtilities.IsAlly(npc, player))
+                return true;
+
+            if (EntityTargetingUtilities.IsFightingFollowers(player, npc))
+                return false;
+
+            return !EntityTargetingUtilities.IsEnemyByFaction(npc, player);
+        }
+
     }
 }


### PR DESCRIPTION
This only happens if the "AdvancedEnemyNPCs" feature flag is enabled.