### PR TITLE
Dialog requirement changes

### DIFF
--- a/0-SCore/0-SCore.csproj
+++ b/0-SCore/0-SCore.csproj
@@ -269,6 +269,7 @@
     <Compile Include="Scripts\Dialogs\DialogRequirementHasItemSDX.cs" />
     <Compile Include="Scripts\Dialogs\DialogRequirementHasPlayerLevelSDX.cs" />
     <Compile Include="Scripts\Dialogs\DialogRequirementHasQuestSDX.cs" />
+    <Compile Include="Scripts\Dialogs\DialogRequirementIsSleeper.cs" />
     <Compile Include="Scripts\Dialogs\DialogRequirementLeader.cs" />
     <Compile Include="Scripts\Dialogs\DialogRequirementHiredSDX.cs" />
     <Compile Include="Scripts\Dialogs\DialogRequirementNPCHasCVar.cs" />

--- a/0-SCore/0-SCore.csproj
+++ b/0-SCore/0-SCore.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -274,6 +274,7 @@
     <Compile Include="Scripts\Dialogs\DialogRequirementNPCHasCVar.cs" />
     <Compile Include="Scripts\Dialogs\DialogRequirementNPCHasItemSDX.cs" />
     <Compile Include="Scripts\Dialogs\DialogRequirementRandomRoll.cs" />
+    <Compile Include="Scripts\Dialogs\IDialogOperator.cs" />
     <Compile Include="Scripts\EAI\DMTEAIUtilities.cs" />
     <Compile Include="Scripts\EAI\EAIApproachAndAttackSDX.cs" />
     <Compile Include="Scripts\EAI\EAIApproachAndFollowTargetSDX.cs" />

--- a/0-SCore/Config/dialogs.xml
+++ b/0-SCore/Config/dialogs.xml
@@ -396,4 +396,41 @@
     
     -->
   </insertBefore>
+
+  <!--
+    Un-comment to add dialog options to the vanilla trader to test "HasCVarSDX, SCore".
+    This should show the expected behavior when the cvar is zero, with and without the "not" operator.
+  -->
+  <!--
+  <insertBefore xpath="//dialog[@id='trader']/statement[@id='start']/response_entry[1]">
+    <response_entry id="ResponseCrouching" />
+    <response_entry id="ResponseStandingUp" />
+    <response_entry id="ResponseStandingUp2" />
+    <response_entry id="ResponseStandingUp3" />
+    <response_entry id="ResponseStandingUp4" />
+  </insertBefore>
+
+  <insertAfter xpath="//dialog[@id='trader']/statement[last()]">
+    <statement id="StatementWhatevs" text="Awww, good for you." nextstatementid="start" />
+    <statement id="StatementDeCrouching" text="You are de-crouching!" nextstatementid="start" />
+  </insertAfter>
+
+  <insertAfter xpath="//dialog[@id='trader']/response[last()]">
+    <response id="ResponseCrouching" text="I am crouching!" nextstatementid="StatementWhatevs">
+      <requirement type="HasCVarSDX, SCore" value="1" requirementtype="Hide" operator="GTE" id="_crouching" />
+    </response>
+    <response id="ResponseStandingUp" text="I am not crouching!" nextstatementid="StatementWhatevs">
+      <requirement type="HasCVarSDX, SCore" value="0" requirementtype="Hide" operator="EQ" id="_crouching" />
+    </response>
+    <response id="ResponseStandingUp2" text="I am not crouching?" nextstatementid="StatementWhatevs">
+      <requirement type="HasCVarSDX, SCore" value="1" requirementtype="Hide" operator="not" id="_crouching" />
+    </response>
+    <response id="ResponseStandingUp3" text="I am not crouching..." nextstatementid="StatementWhatevs">
+      <requirement type="HasCVarSDX, SCore" value="0" requirementtype="Hide" operator="not" id="_crouching" />
+    </response>
+    <response id="ResponseStandingUp4" text="Am I not crouching?!" nextstatementid="StatementDeCrouching">
+      <requirement type="HasCVarSDX, SCore" requirementtype="Hide" operator="not" id="_crouching" />
+    </response>
+  </insertAfter>
+  -->
 </configs>

--- a/0-SCore/Harmony/Dialog/DialogFromXML.cs
+++ b/0-SCore/Harmony/Dialog/DialogFromXML.cs
@@ -1,5 +1,4 @@
 using HarmonyLib;
-using System.Xml;
 using System.Xml.Linq;
 
 /**
@@ -21,30 +20,24 @@ public class SphereII_DialogFromXML_Extensions
     {
         static void Postfix(BaseDialogRequirement __result, XElement e)
         {
-            if (__result is DialogRequirementHasCVarSDX)
+            if (__result is IDialogOperator dialogOperatorRequirement &&
+                e.HasAttribute("operator"))
             {
-                if (e.HasAttribute("operator"))
-                    (__result as DialogRequirementHasCVarSDX).strOperator = e.GetAttribute("operator");
-            }
-
-
-            if (__result is DialogRequirementFactionValue)
-            {
-                if (e.HasAttribute("operator"))
-                    (__result as DialogRequirementFactionValue).strOperator = e.GetAttribute("operator");
+                dialogOperatorRequirement.Operator = e.GetAttribute("operator");
             }
         }
     }
+
     [HarmonyPatch(typeof(DialogFromXml))]
     [HarmonyPatch("ParseAction")]
     public class SphereII__DialogFromXML_ParseAction
     {
         static void Postfix(BaseDialogAction __result, XElement e)
         {
-            if (__result is DialogActionAddCVar)
+            if (__result is IDialogOperator dialogOperatorAction &&
+                e.HasAttribute("operator"))
             {
-                if (e.HasAttribute("operator"))
-                    (__result as DialogActionAddCVar).strOperator = e.GetAttribute("operator");
+                dialogOperatorAction.Operator = e.GetAttribute("operator");
             }
 
         }

--- a/0-SCore/Scripts/Dialogs/DialogActionAddCVar.cs
+++ b/0-SCore/Scripts/Dialogs/DialogActionAddCVar.cs
@@ -1,8 +1,8 @@
-﻿public class DialogActionAddCVar : DialogActionAddBuff
+﻿public class DialogActionAddCVar : DialogActionAddBuff, IDialogOperator
 {
     private static readonly string AdvFeatureClass = "AdvancedDialogDebugging";
 
-    public string strOperator = "add";
+    public string Operator { get; set; } = "add";
 
     public override void PerformAction(EntityPlayer player)
     {
@@ -11,7 +11,7 @@
 
         int.TryParse(Value, out var flValue);
 
-        var strDisplay = "AddCVar: " + ID + " Value: " + flValue + " Operator: " + strOperator;
+        var strDisplay = "AddCVar: " + ID + " Value: " + flValue + " Operator: " + Operator;
         if (!player.Buffs.HasCustomVar(ID))
         {
             AdvLogging.DisplayLog(AdvFeatureClass, strDisplay + " Adding Custom CVAr");
@@ -19,7 +19,7 @@
         }
 
         var currentValue = player.Buffs.GetCustomVar(ID);
-        switch (strOperator.ToLower())
+        switch (Operator.ToLower())
         {
             case "add":
                 currentValue += flValue;

--- a/0-SCore/Scripts/Dialogs/DialogRequirementFactionValue.cs
+++ b/0-SCore/Scripts/Dialogs/DialogRequirementFactionValue.cs
@@ -1,11 +1,11 @@
-﻿public class DialogRequirementFactionValue : BaseDialogRequirement
+﻿public class DialogRequirementFactionValue : BaseDialogRequirement, IDialogOperator
 {
     private static readonly string AdvFeatureClass = "AdvancedDialogDebugging";
     // Show Dialog if player faction is less than 400
     //  <requirement type="FactionValue, SCore" requirementtype="Hide" value="400" operator="lt" /> 
 
-    // strOperator is set in 0-SphereIICore/Harmony/DialogFromXML.cs
-    public string strOperator = "eq";
+    public string Operator { get; set; } = "eq";
+
     public override bool CheckRequirement(EntityPlayer player, EntityNPC talkingTo)
     {
         AdvLogging.DisplayLog(AdvFeatureClass, $"Player: {player.EntityName}");
@@ -24,9 +24,9 @@
 
         float.TryParse(Value, out var flValue);
         var flPlayerValue = FactionManager.Instance.GetRelationshipValue(myEntity, player);
-        AdvLogging.DisplayLog(AdvFeatureClass, $"{GetType()} FactionValue: {ID} Value: {flValue} Player Value: {flPlayerValue} Operator: {strOperator}");
+        AdvLogging.DisplayLog(AdvFeatureClass, $"{GetType()} FactionValue: {ID} Value: {flValue} Player Value: {flPlayerValue} Operator: {Operator}");
 
-        switch (strOperator.ToLower())
+        switch (Operator.ToLower())
         {
             case "lt":
                 {
@@ -66,7 +66,7 @@
                 }
         }
 
-        AdvLogging.DisplayLog(AdvFeatureClass, GetType() + "FactionValue: " + ID + "  Value: " + flValue + " Player Value: " + flPlayerValue + " Operator: " + strOperator + " :: No Result");
+        AdvLogging.DisplayLog(AdvFeatureClass, GetType() + "FactionValue: " + ID + "  Value: " + flValue + " Player Value: " + flPlayerValue + " Operator: " + Operator + " :: No Result");
         AdvLogging.DisplayLog(AdvFeatureClass, "FactionValue:: false");
         return false;
     }

--- a/0-SCore/Scripts/Dialogs/DialogRequirementIsSleeper.cs
+++ b/0-SCore/Scripts/Dialogs/DialogRequirementIsSleeper.cs
@@ -1,0 +1,28 @@
+﻿/// <summary>
+/// <para>
+/// Requires that the dialog's NPC must have been spawned into a prefab sleeper volume.
+/// Putting the value "not" into <see cref="BaseDialogRequirement.Value"/> will negate the result.
+/// </para>
+/// 
+/// <example>
+/// Example: Hide the response unless the NPC is a sleeper.
+/// <code>
+/// &lt;requirement type="IsSleeper, SCore" requirementtype="Hide" />
+/// </code>
+/// </example>
+/// 
+/// <example>
+/// Example: Hide the response unless the NPC is <em>not</em> a sleeper.
+/// <code>
+/// &lt;requirement type="IsSleeper, SCore" requirementtype="Hide" value="not" />
+/// </code>
+/// </example>
+/// </summary>
+public class DialogRequirementIsSleeper : BaseDialogRequirement
+{
+    public override bool CheckRequirement(EntityPlayer player, EntityNPC talkingTo)
+    {
+        var isSleeper = talkingTo.IsSleeper;
+        return Value.EqualsCaseInsensitive("not") ? !isSleeper : isSleeper;
+    }
+}

--- a/0-SCore/Scripts/Dialogs/DialogRequirementLeader.cs
+++ b/0-SCore/Scripts/Dialogs/DialogRequirementLeader.cs
@@ -10,10 +10,11 @@
             return false;
 
         var leader = EntityUtilities.GetLeaderOrOwner(entityId);
-        if (leader == null)
-            return false;
 
-        return leader.entityId == player.entityId;
+        // If value is "not" then we want to return true when the NPC doesn't have any leader,
+        // not just when they have a leader and it's not the player.
+        var playerIsLeader = leader?.entityId == player.entityId;
+        return Value.EqualsCaseInsensitive("not") ? !playerIsLeader : playerIsLeader;
     }
 }
 

--- a/0-SCore/Scripts/Dialogs/DialogRequirementNPCHasCVar.cs
+++ b/0-SCore/Scripts/Dialogs/DialogRequirementNPCHasCVar.cs
@@ -1,75 +1,113 @@
-﻿public class DialogRequirementNPCHasCVarSDX : BaseDialogRequirement
+﻿/// <summary>
+/// <para>
+/// Requires that the dialog's NPC must consider its own cvar specified by <see cref="BaseDialogRequirement.ID"/>,
+/// whose existence and value matches an expression specified by <see cref="IDialogOperator.Operator"/>
+/// and <see cref="BaseDialogRequirement.Value"/>.
+/// </para>
+/// 
+/// <example>
+/// Example: Hide the response unless the NPC has a cvar named "myCVar" with a value less than 5.
+/// <code>
+/// &lt;requirement type="NPCHasCVarSDX, SCore" requirementtype="Hide" id="myCVar" operator="lte" value="5" />
+/// </code>
+/// </example>
+/// 
+/// <example>
+/// Example: Hide the response unless the NPC has a cvar named "myCVar" with any value (including zero).
+/// <code>
+/// &lt;requirement type="NPCHasCVarSDX, SCore" requirementtype="Hide" id="myCVar" />
+/// </code>
+/// </example>
+/// 
+/// <example>
+/// Example: Hide the response unless the NPC does <b>not</b> have a cvar named "myCVar".
+/// <code>
+/// &lt;requirement type="NPCHasCVarSDX, SCore" requirementtype="Hide" id="myCVar" operator="not" />
+/// </code>
+/// </example>
+/// </summary>
+public class DialogRequirementNPCHasCVarSDX : BaseDialogRequirement, IDialogOperator
 {
     private static readonly string AdvFeatureClass = "AdvancedDialogDebugging";
 
-    public string strOperator = "eq";
+    /// <summary>
+    /// <para>
+    /// Operator to use. This is set in
+    /// <see cref="SphereII_DialogFromXML_Extensions.SphereII__DialogFromXML_ParseRequirement"/>.
+    /// </para>
+    /// 
+    /// <para>
+    /// Valid values:
+    /// <list>
+    ///    <item>
+    ///        <term>"eq"</term>
+    ///        <description>
+    ///        The cvar value must exist, and its value must be equal to <see cref="BaseDialogAction.Value"/>.
+    ///        This is the default.
+    ///        </description>
+    ///    </item>
+    ///    <item>
+    ///        <term>"neq"</term>
+    ///        <description>The cvar value must not be equal to <see cref="BaseDialogAction.Value"/>.</description>
+    ///    </item>
+    ///    <item>
+    ///        <term>"lt"</term>
+    ///        <description>The cvar value must be strictly less than <see cref="BaseDialogAction.Value"/>.</description>
+    ///    </item>
+    ///    <item>
+    ///        <term>"lte"</term>
+    ///        <description>The cvar value must be less than or equal to <see cref="BaseDialogAction.Value"/>.</description>
+    ///    </item>
+    ///    <item>
+    ///        <term>"gt"</term>
+    ///        <description>The cvar value must be strictly greater than <see cref="BaseDialogAction.Value"/>.</description>
+    ///    </item>
+    ///    <item>
+    ///        <term>"gte"</term>
+    ///        <description>The cvar value must be greater than or equal to <see cref="BaseDialogAction.Value"/>.</description>
+    ///    </item>
+    ///    <item>
+    ///        <term>"not"</term>
+    ///        <description>The cvar must not exist, or its value must be equal to zero. <see cref="BaseDialogAction.Value"/> is ignored.</description>
+    ///    </item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    public string Operator { get; set; } = "eq";
+
     public override bool CheckRequirement(EntityPlayer player, EntityNPC talkingTo)
     {
-        
-        // If the character doesn't have a cvar, add it.
-        if (!talkingTo.Buffs.HasCustomVar(ID))
-            talkingTo.Buffs.SetCustomVar(ID, 0);
+        var invert = Operator.ToLower() == "not";
 
         if (talkingTo.Buffs.HasCustomVar(ID))
         {
-            // If value is not specified, accepted it.
-            if (string.IsNullOrEmpty(Value))
-                return true;
-
-            float.TryParse(Value, out var flValue);
             var npcValue = talkingTo.Buffs.GetCustomVar(ID);
-            switch (strOperator.ToLower())
+
+            // If value is not specified, accepted it, unless the cvar isn't supposed to exist.
+            if (string.IsNullOrEmpty(Value))
             {
-                case "lt":
-                    {
-                        if (npcValue < flValue)
-                            return true;
-                        break;
-                    }
-                case "lte":
-                    {
-                        if (npcValue <= flValue)
-                            return true;
-                        break;
-                    }
-                case "gt":
-                    {
-                        if (npcValue > flValue)
-                            return true;
-                        break;
-                    }
-                case "gte":
-                    {
-                        if (npcValue >= flValue)
-                            return true;
-                        break;
-                    }
-                case "neq":
-                    {
-                        if (flValue != npcValue)
-                            return true;
-                        break;
-                    }
-                default:
-                    {
-                        if (flValue == npcValue)
-                            return true;
-                        break;
-                    }
+                var passes = invert ? npcValue == 0 : true;
+                AdvLogging.DisplayLog(AdvFeatureClass, $"{GetType()} HasCvar: {ID} Operator: {Operator} Value is empty, returning {passes}");
+                return passes;
             }
 
-        }
-        else if (strOperator.ToLower() == "not")
-            return true;
+            float.TryParse(Value, out var flValue);
 
-        // If the Cvar does not exist, but does have a value to be checked, pass the condition.It just may not be set yet.
-        if (string.IsNullOrEmpty(Value))
-        {
-            return true;
+            AdvLogging.DisplayLog(AdvFeatureClass, $"{GetType()} HasCvar: {ID} Value: {flValue} NPC Value: {npcValue} Operator: {Operator}");
+
+            return Operator.ToLower() switch
+            {
+                "lt" => npcValue < flValue,
+                "lte" => npcValue <= flValue,
+                "gt" => npcValue > flValue,
+                "gte" => npcValue >= flValue,
+                "neq" => flValue != npcValue,
+                "not" => npcValue == 0,
+                _ => flValue == npcValue,
+            }; ;
         }
-        return false;
+
+        return invert;
     }
 
 }
-
-

--- a/0-SCore/Scripts/Dialogs/IDialogOperator.cs
+++ b/0-SCore/Scripts/Dialogs/IDialogOperator.cs
@@ -1,0 +1,11 @@
+﻿/// <summary>
+/// Interface for dialog actions or requirements that accept an "operator" attribute.
+/// It places no restrictions on the values that the "operator" attribute may have.
+/// </summary>
+public interface IDialogOperator
+{
+    /// <summary>
+    /// Contains the raw string value of the "operator" attribute.
+    /// </summary>
+    string Operator { get; set; }
+}


### PR DESCRIPTION
* Added `IDialogOperator` interface for requirements and actions that accept an "operator" attribute
* Updated Harmony patches to `DialogFromXML` to use the interface
* `DialogActionAddCVar`, `DialogRequirementFactionValue`, `DialogRequirementHasCvar`, and `DialogRequirementNPCHasCVar` now all implement that interface
* Major refactoring of `DialogRequirementNPCHasCVar`
* `DialogRequirementHasCVar` handles "not" operator better
* `DialogRequirementLeader` supports "not" as a value, which checks that the NPC is not hired by the player talking to it (as opposed to "HiredSDX" which just checks whether or not the NPC is hired by _any_ player)
* Added XPath in `dialogs.xml` that will test the various values of "HasCVarSDX" (the XPath is commented out)