### PR TITLE
Fix for issues with explosions and "followers of followers"

### DIFF
--- a/0-SCore/Scripts/Entities/EntityTargetingUtilities.cs
+++ b/0-SCore/Scripts/Entities/EntityTargetingUtilities.cs
@@ -42,8 +42,8 @@ public static class EntityTargetingUtilities
         if (selfPlayer != null)
         {
             // If you or your leader are a player, don't damage your followers or fellow followers.
-            if (IsAlly(target, self))
-                return CanDamageAlly(target, self);
+            if (IsAlly(target, selfPlayer))
+                return CanDamageAlly(target, selfPlayer);
 
             // If two players are involved (directly or as leaders), determine whether they or
             // their followers can damage each other from the "Player Killing" setting.
@@ -55,7 +55,7 @@ public static class EntityTargetingUtilities
             }
 
             // Otherwise, use factions.
-            return !IsFriendlyFireByFaction(self, target);
+            return !IsFriendlyFireByFaction(target, selfPlayer);
         }
 
         // You can always damage your revenge target, even if it's a player (since they hit first).


### PR DESCRIPTION
The "followers of followers" issue is solved by replacing calls to `EntityUtilities.GetLeaderOrOwner` with calls to a new method that searches the "chain of command" until it finds a leader/owner that does not itself have a leader/owner.

The issue with explosions was not actually an issue with explosions. It was an issue with the `CanDamage` method.

That method was checking to see if both `self` and `target` have leaders who are players, and if so, uses the vanilla `FriendlyFireCheck` method to see if one player can damage another.

But hires have a player leader - their leader - and the player also has a "player leader" - itself. And the vanilla `FriendlyFireCheck` method allows players to damage themselves (which is how they can be set on fire by their own Molotovs).

So `CanDamage` was _always_ returning true when determining whether a player can damage their hires. We didn't notice it with other damage types because of the patch to `Entity.CanDamageEntity` which is called whenever a player uses an item in their hands to damage anything.