### PR TITLE
Changes for NPC "forgiveness"/reset revenge target

### DIFF
--- a/0-SCore/0-SCore.csproj
+++ b/0-SCore/0-SCore.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Scripts\Blocks\BlockSpawnerSDX.cs" />
     <Compile Include="Scripts\Blocks\BlockTriggeredSDX.cs" />
     <Compile Include="Scripts\Blocks\BlockUtilitiesSDX.cs" />
+    <Compile Include="Scripts\Buffs\FactionRelationshipValue.cs" />
     <Compile Include="Scripts\Buffs\HoldingItemDurability.cs" />
     <Compile Include="Scripts\Buffs\RequirementEveryDawn.cs" />
     <Compile Include="Scripts\Buffs\RequirementEveryXDaySDX.cs" />
@@ -238,6 +239,7 @@
     <Compile Include="Scripts\Buffs\RequirementOnSpecificBiomeSDX.cs" />
     <Compile Include="Scripts\Buffs\RequirementIsNearFire.cs" />
     <Compile Include="Scripts\Buffs\RequirementSameFactionSDX.cs" />
+    <Compile Include="Scripts\Buffs\TargetCVarCompare.cs" />
     <Compile Include="Scripts\Cache\SCoreQueue.cs" />
     <Compile Include="Scripts\Cache\SphereCache.cs" />
     <Compile Include="Scripts\ConsoleCmd\ConsoleCmdActionFireClear.cs" />
@@ -354,6 +356,7 @@
     <Compile Include="Scripts\MinEvents\MinEventActionModifyRelatedFactionsSDX.cs" />
     <Compile Include="Scripts\MinEvents\MinEventActionModifySkillSDX.cs" />
     <Compile Include="Scripts\MinEvents\MinEventActionClearStaleHires.cs" />
+    <Compile Include="Scripts\MinEvents\MinEventActionSetRevengeTarget.cs" />
     <Compile Include="Scripts\MinEvents\MinEventActionSpawnEntityAtPoint.cs" />
     <Compile Include="Scripts\MinEvents\MinEventActionSwapWeapon.cs" />
     <Compile Include="Scripts\MinEvents\MinEventActionTeamTeleportNow.cs" />

--- a/0-SCore/Config/buffs.xml
+++ b/0-SCore/Config/buffs.xml
@@ -146,6 +146,68 @@
 			</effect_group>
 
 		</buff>
+
+		<!--
+			This buff is an example of how you can use SCore cvars, requirements, and triggered
+			actions to implement a "forgiveness" mechanic for NPCs. It does this by resetting the
+			revenge target if certain rules are met.
+
+			The "forgiveness" rules:
+			* If the faction relationship between the NPC and the revenge target is "like" or higher,
+			  forgive immediately.
+			* If the faction relationship between the NPC and the revenge target is "neutral",
+			  forgive after the NPC hits back once, OR after five seconds.
+			* Otherwise, let the revenge play out.
+
+			Note: The revenge target does not get set until AFTER the onOtherAttackedSelf and
+			onOtherDamagedSelf events are triggered. Setting the revenge target on these events
+			will have no effect. Instead, use the onCombatEntered event.
+		-->
+		<buff name="buffNPCForgiveness" hidden="true" remove_on_death="false">
+			<stack_type value="ignore" />
+			<effect_group name="Like or Love">
+				<triggered_effect trigger="onCombatEntered" action="SetRevengeTarget, SCore" value="0">
+					<requirement name="FactionRelationshipValue, SCore" operation="GTE" value="like" />
+				</triggered_effect>
+			</effect_group>
+			<effect_group name="Neutral">
+				<!-- Remember the previous revenge target ID -->
+				<triggered_effect trigger="onOtherDamagedSelf" action="ModifyCVar" cvar="$prevRevengeTarget" operation="set" value="@_revengeTargetId" />
+				<!-- Remove the existing "reset" buff if this isn't the same revenge target -->
+				<triggered_effect trigger="onCombatEntered" action="RemoveBuff" buff="buffResetRevengeTargetWhenFinished">
+					<requirement name="CVarCompare" cvar="$prevRevengeTarget" operation="NotEquals" value="@_revengeTargetId" />
+				</triggered_effect>
+				<!-- Now, add/stack the "reset" buff for this revenge target -->
+				<triggered_effect trigger="onCombatEntered" action="AddBuff" buff="buffResetRevengeTargetWhenFinished">
+					<requirement name="FactionRelationshipValue, SCore" operation="GTE" value="neutral" />
+					<requirement name="FactionRelationshipValue, SCore" operation="LT" value="like" />
+				</triggered_effect>
+				<!-- Once you have taken revenge on the target once, forgive them -->
+				<triggered_effect trigger="onSelfAttackedOther" action="SetRevengeTarget, SCore" value="0">
+					<requirement name="FactionRelationshipValue, SCore" operation="GTE" value="neutral" />
+					<requirement name="FactionRelationshipValue, SCore" operation="LT" value="like" />
+					<requirement name="TargetCVarCompare, SCore" cvar="_revengeTargetId" operation="EQ" targetcvar="_entityId" />
+				</triggered_effect>
+				<!-- Remove the "reset" buff after you take your revenge -->
+				<triggered_effect trigger="onSelfAttackedOther" action="RemoveBuff" buff="buffResetRevengeTargetWhenFinished">
+					<requirement name="FactionRelationshipValue, SCore" operation="GTE" value="neutral" />
+					<requirement name="FactionRelationshipValue, SCore" operation="LT" value="like" />
+					<requirement name="TargetCVarCompare, SCore" cvar="_revengeTargetId" operation="EQ" targetcvar="_entityId" />
+				</triggered_effect>
+			</effect_group>
+		</buff>
+
+		<!--
+			Buff that resets the revenge target when its time runs out, in this case after 5 seconds.
+			Stacking the buff will add an extra 5 seconds.
+		-->
+		<buff name="buffResetRevengeTargetWhenFinished" hidden="true" remove_on_death="false">
+			<duration value="5" />
+			<stack_type value="duration" />
+			<effect_group>
+				<triggered_effect trigger="onSelfBuffFinish" action="SetRevengeTarget, SCore" value="0" />
+			</effect_group>
+		</buff>
 	</append>
 
 </configs>

--- a/0-SCore/Harmony/EntityAlive/EntityAlivePatches.cs
+++ b/0-SCore/Harmony/EntityAlive/EntityAlivePatches.cs
@@ -72,5 +72,47 @@ namespace Harmony.EntityAlive
 
         //    }
         //}
+
+        /// <summary>
+        /// Postfix for <see cref="global::EntityAlive.PostInit"/> that adds a read-only cvar
+        /// containing the entity ID.
+        /// </summary>
+        [HarmonyPatch(typeof(global::EntityAlive), nameof(global::EntityAlive.PostInit))]
+        public static class EntityAlivePostInit
+        {
+            [HarmonyPostfix]
+            public static void Postfix(global::EntityAlive __instance)
+            {
+                __instance.SetCVar("_entityId", __instance.entityId);
+            }
+        }
+
+        /// <summary>
+        /// Postfix for <see cref="global::EntityAlive.SetAttackTarget"/> that adds a read-only
+        /// cvar containing the attack target's entity ID.
+        /// </summary>
+        [HarmonyPatch(typeof(global::EntityAlive), nameof(global::EntityAlive.SetAttackTarget))]
+        public static class EntityAliveSetAttackTarget
+        {
+            [HarmonyPostfix]
+            public static void Postfix(global::EntityAlive __instance)
+            {
+                __instance.SetCVar("_attackTargetId", __instance.GetAttackTarget()?.entityId ?? 0);
+            }
+        }
+
+        /// <summary>
+        /// Postfix for <see cref="global::EntityAlive.SetRevengeTarget"/> that adds a read-only
+        /// cvar containing the revenge target's entity ID.
+        /// </summary>
+        [HarmonyPatch(typeof(global::EntityAlive), nameof(global::EntityAlive.SetRevengeTarget))]
+        public static class EntityAliveSetRevengeTarget
+        {
+            [HarmonyPostfix]
+            public static void Postfix(global::EntityAlive __instance)
+            {
+                __instance.SetCVar("_revengeTargetId", __instance.GetRevengeTarget()?.entityId ?? 0);
+            }
+        }
     }
 }

--- a/0-SCore/Scripts/Buffs/FactionRelationshipValue.cs
+++ b/0-SCore/Scripts/Buffs/FactionRelationshipValue.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Xml.Linq;
+
+/// <summary>
+/// <para>
+/// Compares the faction relationship between the entity holding the buff ("self") and the target.
+/// The <c>value</c> attribute can be the name of a faction relationship, or a standard numeric
+/// value (a float or a cvar value).
+/// </para>
+/// 
+/// <para>
+/// Here are the valid faction relationship names, and their numeric relationship values.
+/// <list type="bullet">
+/// <item>"hate": 0</item>
+/// <item>"dislike": 200</item>
+/// <item>"neutral": 400</item>
+/// <item>"like": 600</item>
+/// <item>"love": 800</item>
+/// </list>
+/// The names are not case-sensitive.
+/// </para>
+/// 
+/// <para>
+/// The names' values are the <em>lower limit</em> in the range of values for that relationship.
+/// For example, anything below 200 is considered "hate," but if you specify the relationship
+/// value <em>using the name "hate",</em> then the relationship value will be zero.
+/// </para>
+/// 
+/// <example>
+/// Example: The faction relationship must be "like" or higher.
+/// <code>
+/// &lt;requirement name="FactionRelationshipValue, SCore" operation="GTE" value="like" />
+/// &lt;!-- You can also use the numeric value for "like": -->
+/// &lt;requirement name="FactionRelationshipValue, SCore" operation="GTE" value="600" />
+/// </code>
+/// </example>
+/// 
+/// <example>
+/// Example: You have set a custom cvar named "charisma", with a value of 0 - 1000, and the faction
+/// relationship must be lower than that value.
+/// <code>
+/// &lt;requirement name="FactionRelationshipValue, SCore" operation="LT" value="@charisma" />
+/// </code>
+/// </example>
+/// </summary>
+public class FactionRelationshipValue : RequirementBase
+{
+    public override bool IsValid(MinEventParams _params)
+    {
+        if (!ParamsValid(_params))
+        {
+            return false;
+        }
+
+        var isValid = compareValues(GetFactionRelationship(_params), operation, value);
+
+        return invert ? !isValid : isValid;
+    }
+
+    public override bool ParamsValid(MinEventParams _params)
+    {
+        if (!base.ParamsValid(_params))
+        {
+            return false;
+        }
+
+        return _params.Self && _params.Other;
+    }
+
+    public override bool ParseXAttribute(XAttribute _attribute)
+    {
+        if (string.Equals(_attribute.Name.LocalName, "value", StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrEmpty(_attribute.Value)
+            && Enum.TryParse<FactionManager.Relationship>(
+                _attribute.Value.ToLower(),
+                true,
+                out var relationship))
+        {
+            value = (int)relationship;
+            return true;
+        }
+
+        return base.ParseXAttribute(_attribute);
+    }
+
+    private static float GetFactionRelationship(MinEventParams _params)
+    {
+        // If this is moved to SCore, we can use EntityUtilities.GetFactionRelationship.
+        // In the meantime, if we're a player, then we need to switch the checking/target entities
+        // because player factions don't have relationship values defined.
+        var checkingEntity = _params.Self;
+        var targetEntity = _params.Other;
+        if (_params.Self is EntityPlayer)
+        {
+            checkingEntity = _params.Other;
+            targetEntity = _params.Self;
+        }
+
+        return FactionManager.Instance.GetRelationshipValue(
+            checkingEntity,
+            targetEntity);
+    }
+}

--- a/0-SCore/Scripts/Buffs/FactionRelationshipValue.cs
+++ b/0-SCore/Scripts/Buffs/FactionRelationshipValue.cs
@@ -85,19 +85,8 @@ public class FactionRelationshipValue : RequirementBase
 
     private static float GetFactionRelationship(MinEventParams _params)
     {
-        // If this is moved to SCore, we can use EntityUtilities.GetFactionRelationship.
-        // In the meantime, if we're a player, then we need to switch the checking/target entities
-        // because player factions don't have relationship values defined.
-        var checkingEntity = _params.Self;
-        var targetEntity = _params.Other;
-        if (_params.Self is EntityPlayer)
-        {
-            checkingEntity = _params.Other;
-            targetEntity = _params.Self;
-        }
-
-        return FactionManager.Instance.GetRelationshipValue(
-            checkingEntity,
-            targetEntity);
+        return EntityUtilities.GetFactionRelationship(
+            _params.Self,
+            _params.Other);
     }
 }

--- a/0-SCore/Scripts/Buffs/TargetCVarCompare.cs
+++ b/0-SCore/Scripts/Buffs/TargetCVarCompare.cs
@@ -18,7 +18,7 @@ using System.Xml.Linq;
 /// Example: Require that the "self" entity's vanilla "bleedCounter" cvar is greater than or equal
 /// to a cvar named "bleedChance" on the target entity.
 /// <code>
-/// &lt;requirement name="TargetCVarCompare, RevengeTargetUtils" cvar="bleedCounter" operation="GTE" targetcvar="bleedChance" />
+/// &lt;requirement name="TargetCVarCompare, SCore" cvar="bleedCounter" operation="GTE" targetcvar="bleedChance" />
 /// </code>
 /// </example>
 /// 
@@ -27,7 +27,7 @@ using System.Xml.Linq;
 /// to the vanilla "bleedCounter" cvar on the target entity. Since the cvars have the same name,
 /// the "targetcvar" attribute is optional.
 /// <code>
-/// &lt;requirement name="TargetCVarCompare, RevengeTargetUtils" cvar="bleedCounter" operation="GTE" />
+/// &lt;requirement name="TargetCVarCompare, SCore" cvar="bleedCounter" operation="GTE" />
 /// </code>
 /// </example>
 /// </summary>

--- a/0-SCore/Scripts/Buffs/TargetCVarCompare.cs
+++ b/0-SCore/Scripts/Buffs/TargetCVarCompare.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Xml.Linq;
+
+/// <summary>
+/// <para>
+/// Compares the value of a cvar on the entity holding the buff ("self"), with the value of a cvar
+/// on the target entity. The "self" value is always on the left-hand side of the operation.
+/// the operation.
+/// </para>
+/// 
+/// <para>
+/// If only the "cvar" attribute is specified, it is used as the name of the cvar on the "self"
+/// entity <em>and</em> the target entity. So, if you want to compare the same cvar on both
+/// entities, you do not need to specify the "targetcvar" attribute.
+/// </para>
+/// 
+/// <example>
+/// Example: Require that the "self" entity's vanilla "bleedCounter" cvar is greater than or equal
+/// to a cvar named "bleedChance" on the target entity.
+/// <code>
+/// &lt;requirement name="TargetCVarCompare, RevengeTargetUtils" cvar="bleedCounter" operation="GTE" targetcvar="bleedChance" />
+/// </code>
+/// </example>
+/// 
+/// <example>
+/// Example: Require that the "self" entity's vanilla "bleedCounter" cvar is greater than or equal
+/// to the vanilla "bleedCounter" cvar on the target entity. Since the cvars have the same name,
+/// the "targetcvar" attribute is optional.
+/// <code>
+/// &lt;requirement name="TargetCVarCompare, RevengeTargetUtils" cvar="bleedCounter" operation="GTE" />
+/// </code>
+/// </example>
+/// </summary>
+public class TargetCVarCompare : RequirementBase
+{
+    private string selfCVarName;
+    private string targetCVarName;
+
+    public override bool IsValid(MinEventParams _params)
+    {
+        if (!ParamsValid(_params))
+        {
+            return false;
+        }
+
+        var isValid = compareValues(
+            _params.Self.GetCVar(selfCVarName),
+            operation,
+            _params.Other.GetCVar(targetCVarName));
+
+        return invert ? !isValid : isValid;
+    }
+
+    public override bool ParamsValid(MinEventParams _params)
+    {
+        if (!base.ParamsValid(_params))
+        {
+            return false;
+        }
+
+        return _params.Self && _params.Other;
+    }
+
+    public override bool ParseXAttribute(XAttribute _attribute)
+    {
+        var localName = _attribute.Name.LocalName;
+
+        if (string.Equals(localName, "cvar", StringComparison.OrdinalIgnoreCase))
+        {
+            selfCVarName = _attribute.Value;
+            targetCVarName ??= _attribute.Value;
+            return true;
+        }
+
+        if (string.Equals(localName, "targetcvar", StringComparison.OrdinalIgnoreCase))
+        {
+            targetCVarName = _attribute.Value;
+            return true;
+        }
+
+        return base.ParseXAttribute(_attribute);
+    }
+}

--- a/0-SCore/Scripts/Buffs/TargetCVarCompare.cs
+++ b/0-SCore/Scripts/Buffs/TargetCVarCompare.cs
@@ -5,7 +5,6 @@ using System.Xml.Linq;
 /// <para>
 /// Compares the value of a cvar on the entity holding the buff ("self"), with the value of a cvar
 /// on the target entity. The "self" value is always on the left-hand side of the operation.
-/// the operation.
 /// </para>
 /// 
 /// <para>

--- a/0-SCore/Scripts/MinEvents/MinEventActionSetRevengeTarget.cs
+++ b/0-SCore/Scripts/MinEvents/MinEventActionSetRevengeTarget.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Xml.Linq;
+
+/// <summary>
+/// <para>
+/// This is a <see cref="MinEventActionTargetedBase"/> that will set the revenge target of all the
+/// target entities.
+/// </para>
+/// <para>
+/// This action takes a <c>value</c> attribute, which should be the entity ID of the revenge target.
+/// If the value of the attribute is 0 or less, the revenge target will be set to null.
+/// Omitting the "value" attribute will also set the revenge target to null.
+/// </para>
+/// 
+/// <example>
+/// Example: Set the revenge target of the entity you're attacking, to yourself.
+/// This uses the read-only "_entityId" cvar that is introduced in this mod.
+/// (This is only an example; the game does this automatically.)
+/// <code>
+/// &lt;triggered_effect trigger="onSelfAttackedOther" action="SetRevengeTarget, SCore" target="other" value="@_entityId" />
+/// </code>
+/// </example>
+/// 
+/// <example>
+/// Example: When the buff updates, set the revenge targets of everything within 10 meters of you,
+/// with the "friendly" tag, to your own revenge target, if you have one.
+/// This uses the read-only "_revengeTargetId" cvar that is introduced in this mod.
+/// <code>
+/// &lt;triggered_effect trigger = "onSelfBuffUpdate" action="SetRevengeTarget, SCore" target="selfAOE" range="10" target_tags="friendly" value="@_revengeTargetId">
+///     &lt;requirement name = "CVarCompare" target="self" cvar="_revengeTargetId" operation="GTE" value="0" />
+/// &lt;/triggered_effect>
+/// </code>
+/// </example>
+/// 
+/// <example>
+/// Example: Clear the revenge target of the entity that damaged you.
+/// <code>
+/// &lt;!-- To clear the revenge target, set the "value" attribute to zero: -->
+/// &lt;triggered_effect trigger="onOtherDamagedSelf" action="SetRevengeTarget, SCore" target="other" value="0" />
+/// &lt;!-- You can also use -1 or any other negative number: -->
+/// &lt;triggered_effect trigger="onOtherDamagedSelf" action="SetRevengeTarget, SCore" target="other" value="-1" />
+/// &lt;!-- Or, omit the "value" attribute altogether: -->
+/// &lt;triggered_effect trigger="onOtherDamagedSelf" action="SetRevengeTarget, SCore" target="other" />
+/// </code>
+/// </example>
+/// </summary>
+public class MinEventActionSetRevengeTarget : MinEventActionTargetedBase
+{
+    private int _entityId = 0;
+
+    public override void Execute(MinEventParams _params)
+    {
+        EntityAlive entity = null;
+
+        if (_entityId > 0)
+        {
+            entity = GameManager.Instance.World.GetEntity(_entityId) as EntityAlive;
+        }
+
+        for (var i = 0; i < targets.Count; i++)
+        {
+            targets[i]?.SetRevengeTarget(entity);
+        }
+    }
+
+    public override bool ParseXmlAttribute(XAttribute _attribute)
+    {
+        if (string.Equals(_attribute.Name.LocalName, "value", StringComparison.OrdinalIgnoreCase))
+        {
+            _entityId = StringParsers.ParseSInt32(_attribute.Value);
+            return true;
+        }
+
+        return base.ParseXmlAttribute(_attribute);
+    }
+}


### PR DESCRIPTION
* New Harmony patches to `EntityAlive` to set read-only cvars of entity, attack target, revenge target IDs
* New `FactionRelationshipValue` buff requirement - compares relationship to a value or name of a relationship
* New `TargetCVarCompare` buff requirement - compares "self" cvar value with target cvar value
* New `MinEventActionSetRevengeTarget` action - sets/resets the revenge target (0 or lower resets to null)
* Example buffs in `buffs.xml`