### PR TITLE
Fix mistaken swap of self and target for friendly fire check

### DIFF
--- a/Mods/0-SCore/Scripts/Entities/EntityTargetingUtilities.cs
+++ b/Mods/0-SCore/Scripts/Entities/EntityTargetingUtilities.cs
@@ -55,7 +55,7 @@ public static class EntityTargetingUtilities
             }
 
             // Otherwise, use factions.
-            return !IsFriendlyFireByFaction(target, selfPlayer);
+            return !IsFriendlyFireByFaction(selfPlayer, target);
         }
 
         // You can always damage your revenge target, even if it's a player (since they hit first).


### PR DESCRIPTION
This was a mistake done when fixing the issues with explosions and "followers of followers."

Commit where it happened:
https://github.com/SphereII/SphereII.Mods/commit/65d4e5a1b0d281623e720e3813b630cccca435d8