### PR TITLE
Custom Crouch Height

### DIFF
--- a/Mods/0-SCore/Config/blocks.xml
+++ b/Mods/0-SCore/Config/blocks.xml
@@ -103,6 +103,7 @@
 				<property name="AntiNerdPole" value="false" />
 				<!-- Player cannot jump and place a block under neath them-->
 				<property name="OneBlockCrouch" value="false" />
+				<property name="PhysicsCrouchHeightModifier" value="0.49" />
 				<!-- Allow you to fit through one block spaces -->
 				<property name="SoftHands" value="false" />
 				<!-- Damages the player if they hit something with their bare hands. -->

--- a/Mods/0-SCore/Harmony/PlayerFeatures/OneBlockCrouch.cs
+++ b/Mods/0-SCore/Harmony/PlayerFeatures/OneBlockCrouch.cs
@@ -24,13 +24,13 @@ namespace Harmony.PlayerFeatures
                     return;
 
                 AdvLogging.DisplayLog(AdvFeatureClass, "Activating One Block Crouch");
-                
+
                 __instance.vp_FPController.PhysicsCrouchHeightModifier = 0.49f;
                 var strPhysicsCrouchHeightModifier = Configuration.GetPropertyValue(AdvFeatureClass, "PhysicsCrouchHeightModifier");
                 if (!string.IsNullOrEmpty(strPhysicsCrouchHeightModifier))
                 {
                     __instance.vp_FPController.PhysicsCrouchHeightModifier = StringParsers.ParseFloat(strPhysicsCrouchHeightModifier);
-                    if (__instance.vp_FPController.PhysicsCrouchHeightModifier < 0.10f) // just something to prevent 0f
+                    if (__instance.vp_FPController.PhysicsCrouchHeightModifier < 0.10f) // just something to prevent 0.0f
                         __instance.vp_FPController.PhysicsCrouchHeightModifier = 0.10f;
                     if (__instance.vp_FPController.PhysicsCrouchHeightModifier > 0.75f) // to prevent more than vanilla
                         __instance.vp_FPController.PhysicsCrouchHeightModifier = 0.75f;

--- a/Mods/0-SCore/Harmony/PlayerFeatures/OneBlockCrouch.cs
+++ b/Mods/0-SCore/Harmony/PlayerFeatures/OneBlockCrouch.cs
@@ -24,7 +24,12 @@ namespace Harmony.PlayerFeatures
                     return;
 
                 AdvLogging.DisplayLog(AdvFeatureClass, "Activating One Block Crouch");
+                
                 __instance.vp_FPController.PhysicsCrouchHeightModifier = 0.49f;
+                var strPhysicsCrouchHeightModifier = Configuration.GetPropertyValue(AdvFeatureClass, "PhysicsCrouchHeightModifier");
+                if (!string.IsNullOrEmpty(strPhysicsCrouchHeightModifier))
+                    __instance.vp_FPController.PhysicsCrouchHeightModifier = StringParsers.ParseFloat(strPhysicsCrouchHeightModifier);
+                
                 __instance.vp_FPController.SyncCharacterController();
             }
         }

--- a/Mods/0-SCore/Harmony/PlayerFeatures/OneBlockCrouch.cs
+++ b/Mods/0-SCore/Harmony/PlayerFeatures/OneBlockCrouch.cs
@@ -35,7 +35,7 @@ namespace Harmony.PlayerFeatures
                     if (__instance.vp_FPController.PhysicsCrouchHeightModifier > 0.75f) // to prevent more than vanilla
                         __instance.vp_FPController.PhysicsCrouchHeightModifier = 0.75f;
                 }
-                
+
                 __instance.vp_FPController.SyncCharacterController();
             }
         }

--- a/Mods/0-SCore/Harmony/PlayerFeatures/OneBlockCrouch.cs
+++ b/Mods/0-SCore/Harmony/PlayerFeatures/OneBlockCrouch.cs
@@ -28,7 +28,13 @@ namespace Harmony.PlayerFeatures
                 __instance.vp_FPController.PhysicsCrouchHeightModifier = 0.49f;
                 var strPhysicsCrouchHeightModifier = Configuration.GetPropertyValue(AdvFeatureClass, "PhysicsCrouchHeightModifier");
                 if (!string.IsNullOrEmpty(strPhysicsCrouchHeightModifier))
+                {
                     __instance.vp_FPController.PhysicsCrouchHeightModifier = StringParsers.ParseFloat(strPhysicsCrouchHeightModifier);
+                    if (__instance.vp_FPController.PhysicsCrouchHeightModifier < 0.10f) // just something to prevent 0f
+                        __instance.vp_FPController.PhysicsCrouchHeightModifier = 0.10f;
+                    if (__instance.vp_FPController.PhysicsCrouchHeightModifier > 0.75f) // to prevent more than vanilla
+                        __instance.vp_FPController.PhysicsCrouchHeightModifier = 0.75f;
+                }
                 
                 __instance.vp_FPController.SyncCharacterController();
             }


### PR DESCRIPTION
I have coded this, based on value retrieval of "DistanceEnemy" from blocks.xml.
But I still do not have the environment to compile it, so I cannot grant it is working, and I don't know when I will be able to set it up...

The reason is to be able to move crouched thru 1 block tall terrain (like earth sand snow etc, that the shapes keep changing on every strike), that creates a tunnel with diamond shape and 0.49f won't work there.

So we could experiment, I guess 0.40f will, but only testing to see what happens.

I don't know if it is a good idea to let players tweak this so freely, may be it could be values 1=0.49, 2=0.40, 3=0.30
