### PR TITLE
Disable ray hit events when entities can't be damaged

### DIFF
--- a/Mods/0-SCore/Harmony/EAI/EAITarget.cs
+++ b/Mods/0-SCore/Harmony/EAI/EAITarget.cs
@@ -48,21 +48,9 @@ namespace Harmony.EAI
                 return;
             }
 
-            // allow an override for the action stuff. If its set here, then use faction targeting.
-            if (!EntityUtilities.CheckProperty(__instance.theEntity.entityId, "AllEntitiesUseFactionTargeting"))
-            {
-                // This patches the check for all entities, so if we're not supposed to use faction
-                // targeting for everything, stop now. Otherwise, do the faction check.
-                if (!Configuration.CheckFeatureStatus("AdvancedNPCFeatures", "AllEntitiesUseFactionTargeting"))
-                {
-                    // Even if *all* entities don't use faction targeting, this entity still should
-                    // if it has one of the UseFactions tags. Only stop now if it doesn't.
-                    if (!EntityUtilities.UseFactions(__instance.theEntity))
-                    {
-                        return;
-                    }
-                }
-            }
+            if (!EntityUtilities.UseFactionTargeting(__instance.theEntity))
+                return;
+
             var myRelationship = FactionManager.Instance.GetRelationshipTier(__instance.theEntity, _e);
             switch (myRelationship)
             {

--- a/Mods/0-SCore/Scripts/Entities/EntityUtilities.cs
+++ b/Mods/0-SCore/Scripts/Entities/EntityUtilities.cs
@@ -123,6 +123,26 @@ public static class EntityUtilities
         return false;
     }
 
+    /// <summary>
+    /// Returns true if this entity should use faction targeting, according to feature settings,
+    /// entity properties, or entity tags.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <returns></returns>
+    public static bool UseFactionTargeting(EntityAlive entity)
+    {
+        return
+            // allow an override for the action stuff. If its set here, then use faction targeting.
+            CheckProperty(entity.entityId, "AllEntitiesUseFactionTargeting") ||
+
+            // New feature flag, specific to this feature.
+            Configuration.CheckFeatureStatus(AdvFeatureClass, "AllEntitiesUseFactionTargeting") ||
+
+            // Even if *all* entities don't use faction targeting rules, this entity should if it has
+            // one of the UseFactions tags.
+            UseFactions(entity);
+    }
+
     public static void AddBuffToRadius(string strBuff, Vector3 position, int Radius)
     {
         // If there's no radius, pick 30 blocks.


### PR DESCRIPTION
This is a Harmony patch on `ItemActionDynamic.hitTarget` to disable the firing of "onSelf[Primary|Secondary]Action[Ray|Graze]Hit" events if the holding entity can't damage the target entity.

This is the cause of the stun baton "shock" issue with friendly NPCs. The stun baton itself wasn't hitting or doing damage, but the baton was still charging, and when fully charged, it still shocked the friendly NPC.

I also refactored the logic to determine when an entity should use faction targeting. It was already repeated in two places in the code, and I would need to repeat it a third time in my patch.

I did test to make sure that there were no regressions. I tested with a friendly NPC (Baker), an enemy NPC (Harley), an animal (bear), and zombies (mainly Boe). I made sure that I could still shock everyone except the Baker, and that when they attacked each other, they did damage. I did these tests in both 1.0b336 and 1.1b14.