### PR TITLE
Update EntityNPCBandit.cs

### DIFF
--- a/Mods/0-SCore/Scripts/Entities/EntityNPCBandit.cs
+++ b/Mods/0-SCore/Scripts/Entities/EntityNPCBandit.cs
@@ -123,7 +123,8 @@ public class EntityNPCBandit : EntityBandit, IEntityOrderReceiverSDX
         }
 
         // Potential work around for NPC stuck for 3 seconds in crouch after being stunned
-        if (bodyDamage.CurrentStun is EnumEntityStunType.Getup or EnumEntityStunType.Prone) 
+        // Add null check for bodyDamage
+		if (bodyDamage != null && bodyDamage.CurrentStun is EnumEntityStunType.Getup or EnumEntityStunType.Prone) 
         {
             SetHeight(this.physicsBaseHeight);
         }


### PR DESCRIPTION
Added the following (first line is the line above the added and modified code):

// Potential work around for NPC stuck for 3 seconds in crouch after being stunned		
// Add null check for bodyDamage
		
if (bodyDamage != null && bodyDamage.CurrentStun is EnumEntityStunType.Getup or EnumEntityStunType.Prone)